### PR TITLE
Add license collateral and headers to plain-text artifacts

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,195 @@
+
+End user License Agreement (EULA) for CloudStack Container Service
+
+Please read this EULA carefully, as it sets out the basis upon which we license the Software for use.
+BY INSTALLING THE SOFTWARE, YOU ARE AGREEING TO BE BOUND BY THE TERMS OF THIS EULA. 
+By agreeing to be bound by this EULA, you further agree that your employees will comply with the provision of this EULA.
+
+A formatted version of this EULA is available at http://shapeblue.com/ccs-EULA
+AGREEMENT
+1.	Definitions
+1.1	Except to the extent expressly provided otherwise, in this EULA:
+"Charges" means those amounts that the parties have agreed in writing shall be payable by the User to the Licensor in respect of this EULA;
+"Documentation" means [the documentation for the Software produced by the Licensor and delivered or made available by the Licensor to the User];
+"EULA" means this end user license agreement, including any amendments to this end user license agreement from time to time;
+"Effective Date" means [the date upon which the User gives the User's express consent to this EULA, following the issue of this EULA by the Licensor];
+"Force Majeure Event" means an event, or a series of related events, that is outside the reasonable control of the party affected (including failures of the internet or any public telecommunications network, hacker attacks, denial of service attacks, virus or other malicious software attacks or infections, power failures, industrial disputes affecting any third party, changes to the law, disasters, explosions, fires, floods, riots, terrorist attacks and wars);
+"Intellectual Property Rights" means all intellectual property rights wherever in the world, whether registrable or unregistrable, registered or unregistered, including any application or right of application for such rights (and these "intellectual property rights" include copyright and related rights, database rights, confidential information, trade secrets, know-how, business names, trade names, trade marks, service marks, passing off rights, unfair competition rights, patents, petty patents, utility models, semi-conductor topography rights and rights in designs);
+"Licensor" means Shape Blue Ltd, a company incorporated in England and Wales (registration number 7887184) having its registered office at 71-75 Shelton Street, London, WC2H 9JQ
+"Licensor Indemnity Event" has the meaning given to it in Clause 13.1;
+"Maintenance Services" means the supply to the User of Updates and Upgrades;
+"Minimum Term" means, in respect of this EULA, the period stated on any related Order Documentation beginning on the Effective Date. In the absence of any such documentation, the period of 12 months;
+“Order Documentation” means, in respect of this EULA, any order form, booking form, proposal or other sales document provided to the Licensee by The Licensor that describes the Licensees use of The Software and any Charges for that use.
+"Services" means any services that the Licensor provides to the User, or has an obligation to provide to the User, under this EULA;
+"Software" means CloudStack Container Service
+"Software Defect" means a defect, error or bug in the Software having a material adverse effect on the, operation, functionality or performance of the Software, but excluding any defect, error or bug caused by or arising as a result of:
+(a)	any act or omission of the User or any person authorised by the User to use the Software;
+(b)	Any defect in Apache CloudStack or Kubernetes  that is not specifically part of the Software
+(b)	any use of the Software contrary to the Documentation by the User or any person authorised by the User to use the Software;
+(c)	a failure of the User to perform or observe any of its obligations in this EULA; and/or
+(d)	any existing defect or incompatibility between the Software and any other system, software, application, program, hardware or software.;
+	
+"Source Code" means the Software code in human-readable form or any part of the Software code in human-readable form, including code compiled to create the Software or decompiled from the Software, but excluding interpreted code comprised in the Software;
+"Support Services" means support in relation to the use of the Software and the identification and resolution of errors in the Software, but shall not include the provision of training services whether in relation to the Software or otherwise;
+"Term" means the term of this EULA, commencing in accordance with Clause 3.1 and ending in accordance with Clause 3.2;
+"Trial Version" means a version of the Software, so identified, to be used only to review, demonstrate and evaluate the Software for a limited time period. 
+"Update" means a hotfix, patch or minor version update to the Software;
+"Upgrade" means a major version upgrade of the Software;
+"User" means the person to whom the Licensor grants a right to use the Software under this EULA; and
+"User Indemnity Event" has the meaning given to it in Clause 13.3.
+2.	Credit
+2.1	This document was created using a template from SEQ Legal (http://www.seqlegal.com).
+3.	Term
+3.1	This EULA shall come into force upon the Effective Date.
+3.2	In the case of Trial Software, this EULA shall continue in force for a period which will be specified in the Order Documentation. In the absence of any such documentation, this EULA shall continue in force for a period of 90 days. 
+3.3	In all other cases, this EULA shall continue in force for a period which will be specified in the Order Documentation. In the absence of any such documentation, this EULA shall continue in force for a period of 1 year.
+
+4.	Licence
+4.1	The Licensor hereby grants to the User from the date of supply of the Software to the User until the end of the Term a worldwide, non-exclusive licence to:
+(a)	Install an instance of the software into a CloudStack environment that is no larger than that specified during the supply of the software; and
+(b)	create, store and maintain up to 5 back-up copies of the Software,
+	subject to the limitations and prohibitions set out and referred to in this Clause 4.
+4.2	The User may not sub-license and must not purport to sub-license any rights granted under Clause 4.1 without the prior written consent of the Licensor.
+
+
+4.3	Save to the extent expressly permitted by this EULA or required by applicable law on a non-excludable basis, any licence granted under this Clause 4 shall be subject to the following prohibitions:
+(a)	the User must not sell, resell, rent, lease, loan, supply, publish, distribute or redistribute the Software;
+(b)	the User must not alter, edit or adapt the Software; and
+(c)	the User must not decompile, de-obfuscate or reverse engineer, or attempt to decompile, de-obfuscate or reverse engineer, the Software.
+4.4	The User shall be responsible for the security of copies of the Software supplied to the User under this EULA (or created from such copies) and shall use all reasonable endeavors (including all reasonable security measures) to ensure that access to such copies is restricted to persons authorised to use them under this EULA.
+5.	Source Code
+5.1	Nothing in this EULA shall give to the User or any other person any right to access or use the Source Code or constitute any licence of the Source Code.
+6.	Maintenance Services
+6.1	The Licensor shall provide the Maintenance Services to the User during the Term.
+6.2	The Licensor shall provide the Maintenance Services with reasonable skill and care
+6.3	The Licensor warrants to the User that the application of Updates and Upgrades to the Software by the Licensor will not introduce any Software Defects into the Software.
+6.4	The Licensor warrants to the User that the application of Updates and Upgrades to the Software by the User in accordance with the instructions of the Licensor will not introduce any Software Defects into the Software.
+6.5	The Licensor may suspend the provision of the Maintenance Services if any amount due to be paid by the User to the Licensor is overdue, and the Licensor has given to the User at least 30 days' written notice, following the amount becoming overdue, of its intention to suspend the Maintenance Services on this basis.
+6.6	Either party may terminate the Maintenance Services by giving to the other at least 90 days' written notice expiring on or at any time after the first anniversary of the Effective Date.
+6.7	If the Licensor stops or makes a good faith decision to stop providing maintenance services in relation to the Software to its customers generally, then the Licensor may terminate the Maintenance Services by giving at least 90 days' written notice of termination to the User.
+6.8	If the Maintenance Services are terminated in accordance with the provisions of this Clause 6:
+(a)	the User must pay to the Licensor any outstanding Charges in respect of Maintenance Services provided to the User before the termination of the Maintenance Services;
+(c)	the provisions of this Clause 6, excluding this Clause 6.8, shall cease to apply, but the other provisions of this EULA will continue notwithstanding such termination.
+7.	Support Services
+7.1	No Support Services will be provided as part of this EULA. The Licensor shall provide the Support Services to the User during the Term through a separate CloudStack Infrastructure Support contract.
+
+8.	No assignment of Intellectual Property Rights
+8.1	Nothing in this EULA shall operate to assign or transfer any Intellectual Property Rights from the Licensor to the User, or from the User to the Licensor.
+9.	Charges
+9.1	The User shall pay the Charges to the Licensor in accordance with this EULA.
+9.2	All amounts stated in or in relation to this EULA are, unless the context requires otherwise, stated exclusive of any applicable value added taxes, which will be added to those amounts and payable by the User to the Licensor.
+10.	Payments
+10.1	The Licensor shall issue invoices for the Charges to the User on a monthly, quarterly or annual basis.
+10.2	The User must pay the Charges to the Licensor within the period of 30 days following the issue of an invoice in accordance with this Clause 10.
+10.3	The User must pay the Charges using such payment details as are notified by the Licensor to the User from time to time.
+10.4	If the User does not pay any amount properly due to the Licensor under this EULA, the Licensor may:
+(a)	charge the User interest on the overdue amount at the rate of 8% per annum above the Bank of England base rate from time to time (which interest will accrue daily until the date of actual payment and be compounded at the end of each calendar month); or
+(b)	claim interest and statutory compensation from the User pursuant to the Late Payment of Commercial Debts (Interest) Act 1998.
+11.	Warranties
+11.1	The Licensor warrants to the User that it has the legal right and authority to enter into this EULA and to perform its obligations under this EULA.
+11.2	The Licensor warrants to the User that the Software will be supplied free from viruses, worms, Trojan horses, ransomware, spyware, adware and other malicious software programs; and
+11.3	The Licensor warrants to the User that the Software, when used by the User in accordance with this EULA, will not breach any laws, statutes or regulations applicable under English law.
+11.4	The Licensor warrants to the User that the Software, when used by the User in accordance with this EULA, will not infringe the Intellectual Property Rights of any person in any jurisdiction and under any applicable law.
+11.5	If the Licensor reasonably determines, or any third party alleges, that the use of the Software by the User in accordance with this EULA infringes any person's Intellectual Property Rights, the Licensor may acting reasonably at its own cost and expense:
+(a)	modify the Software in such a way that it no longer infringes the relevant Intellectual Property Rights, providing that any such modification must not introduce any Software Defects into the Software; or
+(b)	procure for the User the right to use the Software in accordance with this EULA.
+11.6	The User warrants to the Licensor that it has the legal right and authority to enter into this EULA and to perform its obligations under this EULA.
+11.7	All of the parties' warranties and representations in respect of the subject matter of this EULA are expressly set out in this EULA. TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, NO OTHER WARRANTIES OR REPRESENTATIONS CONCERNING THE SUBJECT MATTER OF THIS EULA WILL BE IMPLIED INTO THIS EULA OR ANY RELATED CONTRACT.
+12.	Acknowledgements and warranty limitations
+12.1	The User acknowledges that complex software is never wholly free from defects, errors and bugs; and subject to the other provisions of this EULA, the Licensor gives no warranty or representation that the Software will be wholly free from defects, errors and bugs.
+12.2	The User acknowledges that complex software is never entirely free from security vulnerabilities; and subject to the other provisions of this EULA, the Licensor gives no warranty or representation that the Software will be entirely secure.
+12.3	The User acknowledges that the Software is only designed to be compatible with that software specified as compatible by The Licensor; and the Licensor does not warrant or represent that the Software will be compatible with any other software.
+12.4	The User acknowledges that the Licensor will not provide any legal, financial, accountancy or taxation advice under this EULA or in relation to the Software; and, except to the extent expressly provided otherwise in this EULA, the Licensor does not warrant or represent that the Software or the use of the Software by the User will not give rise to any legal liability on the part of the User or any other person.
+13.	Indemnities
+13.1	The Licensor shall indemnify and shall keep indemnified the User against any and all liabilities, damages, losses, costs and expenses (including legal expenses and amounts reasonably paid in settlement of legal claims) suffered or incurred by the User and arising directly or indirectly as a result of any breach by the Licensor of this EULA (a "Licensor Indemnity Event").
+13.2	The User must:
+(a)	upon becoming aware of an actual or potential Licensor Indemnity Event, notify the Licensor;
+(b)	provide to the Licensor all such assistance as may be reasonably requested by the Licensor in relation to the Licensor Indemnity Event;
+(c)	allow the Licensor the exclusive conduct of all disputes, proceedings, negotiations and settlements with third parties relating to the Licensor Indemnity Event; and
+(d)	not admit liability to any third party in connection with the Licensor Indemnity Event or settle any disputes or proceedings involving a third party and relating to the Licensor Indemnity Event without the prior written consent of the Licensor,
+	without prejudice to the Licensor's obligations under Clause 13.1] OR [and the Licensor's obligation to indemnify the User under Clause 13.1 shall not apply unless the User complies with the requirements of this Clause 13.2.
+13.3	The User shall indemnify and shall keep indemnified the Licensor against any and all liabilities, damages, losses, costs and expenses (including legal expenses and amounts reasonably paid in settlement of legal claims) suffered or incurred by the Licensor and arising directly or indirectly as a result of any breach by the User of [this EULA (a "User Indemnity Event").
+13.4	The Licensor must:
+(a)	upon becoming aware of an actual or potential User Indemnity Event, notify the User;
+(b)	provide to the User all such assistance as may be reasonably requested by the User in relation to the User Indemnity Event;
+(c)	allow the User the exclusive conduct of all disputes, proceedings, negotiations and settlements with third parties relating to the User Indemnity Event; and
+(d)	not admit liability to any third party in connection with the User Indemnity Event or settle any disputes or proceedings involving a third party and relating to the User Indemnity Event without the prior written consent of the User,
+	without prejudice to the User's obligations under Clause 13.3] OR [and the User's obligation to indemnify the Licensor under Clause 13.3 shall not apply unless the Licensor complies with the requirements of this Clause 13.4.
+13.5	The indemnity protection set out in this Clause 13 shall be subject to the limitations and exclusions of liability set out in this EULA.
+14.	Limitations and exclusions of liability
+14.1	Nothing in this EULA will:
+(a)	limit or exclude any liability for death or personal injury resulting from negligence;
+(b)	limit or exclude any liability for fraud or fraudulent misrepresentation;
+(c)	limit any liabilities in any way that is not permitted under applicable law; or
+(d)	exclude any liabilities that may not be excluded under applicable law,
+	and, if a party is a consumer, that party's statutory rights will not be excluded or limited by this EULA, except to the extent permitted by law.
+14.2	The limitations and exclusions of liability set out in this Clause 14 and elsewhere in this EULA: 
+(a)	are subject to Clauses 14.1 and 17.6; and
+(b)	govern all liabilities arising under this EULA or relating to the subject matter of this EULA, including liabilities arising in contract, in tort (including negligence) and for breach of statutory duty, except to the extent expressly provided otherwise in this EULA.
+14.3	The Licensor will not be liable to the User in respect of any losses arising out of a Force Majeure Event.
+14.4	The Licensor will not be liable to the User in respect of any loss of profits or anticipated savings.
+14.5	The Licensor will not be liable to the User in respect of any loss of revenue or income.
+14.6	The Licensor will not be liable to the User in respect of any loss of business, contracts or opportunities.
+14.7	The Licensor will not be liable to the User in respect of any loss or corruption of any data, database or software.
+14.8	The Licensor will not be liable to the User in respect of any special, indirect or consequential loss or damage.
+14.9	The liability of the Licensor to the User under this EULA in respect of any event or series of related events shall not exceed the total amount paid and payable by the User to the Licensor under this EULA in the 12 month period preceding the commencement of the event or events.
+14.10	The aggregate liability of the Licensor to the User under this EULA shall not exceed the total amount paid and payable by the User to the Licensor under this EULA]
+15.	Termination
+15.1	The Licensor may terminate this EULA by giving to the User not less than 90 days' written notice of termination, expiring after the end of the Minimum Term.
+15.2	The User may terminate this EULA by giving to the Licensor not less than 90 days' written notice of termination after the end of the Minimum Term.
+15.3	Either party may terminate this EULA immediately by giving written notice of termination to the other party if:
+(a)	the other party commits any material breach of this EULA, and the breach is not remediable;
+(b)	material breach of this EULA, and the breach is remediable but the other party fails to remedy the breach within the period of 90 days following the giving of a written notice to the other party requiring the breach to be remedied; or
+(c)	the other party persistently breaches this EULA (irrespective of whether such breaches collectively constitute a material breach).
+15.4	Either party may terminate this EULA immediately by giving written notice of termination to the other party if:
+(a)	the other party:
+(i)	is dissolved;
+(ii)	ceases to conduct all (or substantially all) of its business;
+(iii)	is or becomes unable to pay its debts as they fall due;
+(iv)	is or becomes insolvent or is declared insolvent; or
+(v)	convenes a meeting or makes or proposes to make any arrangement or composition with its creditors;
+(b)	an administrator, administrative receiver, liquidator, receiver, trustee, manager or similar is appointed over any of the assets of the other party;
+(c)	an order is made for the winding up of the other party, or the other party passes a resolution for its winding up (other than for the purpose of a solvent company reorganisation where the resulting entity will assume all the obligations of the other party under this EULA); or
+(d)	if that other party is an individual:
+(i)	that other party dies;
+(ii)	as a result of illness or incapacity, that other party becomes incapable of managing his or her own affairs; or
+(iii)	that other party is the subject of a bankruptcy petition or order.
+	
+15.5	The Licensor may terminate this EULA immediately by giving written notice to the User if:
+(a)	any amount due to be paid by the User to the Licensor under this EULA is unpaid by the due date and remains unpaid upon the date that that written notice of termination is given; and
+(b)	the Licensor has given to the User at least [30 days'] written notice, following the failure to pay, of its intention to terminate this EULA in accordance with this Clause 15.5.
+16.	Effects of termination
+16.1	Upon the termination of this EULA, all of the provisions of this EULA shall cease to have effect, save that the following provisions of this EULA shall survive and continue to have effect (in accordance with their express terms or otherwise indefinitely): [Clauses 1, 4.1, 4.2, 4.3, 4.4, 10.2, 10.4, 13, 14, 16, 17 and 18]. 
+16.2	The termination of this EULA shall not affect the accrued rights of either party.
+16.3	Within 30 days following the termination of this EULA for any reason the User must pay to the Licensor any Charges in respect of Services provided to the User before the termination of this EULA and in respect of licences in effect before the termination of this EULA without prejudice to the Licensors  other legal rights.
+16.4	For the avoidance of doubt, the licences of the Software in this EULA shall terminate upon the termination of this EULA; and, accordingly, the User must immediately cease to use the Software upon the termination of this EULA.
+16.5	Within 10 Business Days following the termination of this EULA, the User must:
+(a)	return to the Licensor or dispose of as the Licensor may instruct all media in its possession or control containing the Software; and
+(b)	irrevocably delete from all computer systems in its possession or control all copies of the Software.
+17.	General
+17.1	No breach of any provision of this EULA shall be waived except with the express written consent of the party not in breach.
+17.2	If any provision of this EULA is determined by any court or other competent authority to be unlawful and/or unenforceable, the other provisions of this EULA will continue in effect. If any unlawful and/or unenforceable provision would be lawful or enforceable if part of it were deleted, that part will be deemed to be deleted, and the rest of the provision will continue in effect (unless that would contradict the clear intention of the parties, in which case the entirety of the relevant provision will be deemed to be deleted).
+17.3	This EULA may not be varied except by a written document signed by or on behalf of each of the parties.
+17.4	Neither party may without the prior written consent of the other party assign, transfer, charge, license or otherwise deal in or dispose of any contractual rights or obligations under this EULA.
+17.5	This EULA is made for the benefit of the parties, and is not intended to benefit any third party or be enforceable by any third party. The rights of the parties to terminate, rescind, or agree any amendment, waiver, variation or settlement under or relating to this EULA are not subject to the consent of any third party.
+17.6	Nothing in this EULA shall exclude or limit any liability of a party for fraud or fraudulent misrepresentation, or any other liability of a party that may not be excluded or limited under applicable law.
+17.7	Subject to Clauses 14.1 and 17.6, this EULA shall constitute the entire agreement between the parties in relation to the subject matter of this EULA, and shall supersede all previous agreements, arrangements and understandings between the parties in respect of that subject matter.
+17.8	This EULA shall be governed by and construed in accordance with English law.
+17.9	The courts of England shall have exclusive jurisdiction to adjudicate any dispute arising under or in connection with this EULA.
+18.	Interpretation
+18.1	In this EULA, a reference to a statute or statutory provision includes a reference to: 
+(a)	that statute or statutory provision as modified, consolidated and/or re-enacted from time to time; and
+(b)	any subordinate legislation made under that statute or statutory provision.
+18.2	The Clause headings do not affect the interpretation of this EULA.
+18.3	In this EULA, general words shall not be given a restrictive interpretation by reason of being preceded or followed by words indicating a particular class of acts, matters or things.
+
+19.  Trial Version 
+Unless otherwise provided herein, you shall not:
+ (a) in the aggregate, install or use more than one copy of the Trial Version of the Software; or
+(b) download the Trial Version of the Software under more than one username; or
+(c) alter the contents of a hard drive or computer system to enable the use of the Trial Version of the Software for an aggregate period in excess of the trial period for one license to such Trial Version; or
+(d) disclose the results of software performance benchmarks obtained using the Trial Version to any third party without The Licensors prior written consent; or
+(e) use the Trial Version for any application deployment or ultimate production purpose, or 
+(f) use the Trial Version of the Software for a purpose other than the sole purpose of determining whether to purchase a license to a commercial version of the software; provided, however, notwithstanding the foregoing, you are strictly prohibited from installing or using the Trial Version of the Software for any commercial training purpose.
+ 
+

--- a/packaging/centos/ccs.spec
+++ b/packaging/centos/ccs.spec
@@ -19,8 +19,8 @@ Release:   %{_rel}
 
 Version:   %{_ver}
 License:   ShapeBlue License
-Vendor:    ShapeBlue Engineering <engineering@shapeblue.com>
-Packager:  ShapeBlue Engineering <engineering@shapeblue.com>
+Vendor:    Shape Blue Ltd <CCS-help@shapeblue.com>
+Packager:  Shape Blue Ltd <CCS-help@shapeblue.com>
 Group:     System Environment/Libraries
 Source0:   %{name}-%{_maventag}.tgz
 BuildRoot: %{_tmppath}/%{name}-%{_maventag}-%{release}-build

--- a/packaging/debian/control
+++ b/packaging/debian/control
@@ -1,7 +1,7 @@
 Source: cloudstack-ccs
 Section: libs
 Priority: extra
-Maintainer: ShapeBlue Engineering <engineering@shapeblue.com>
+Maintainer: Shape Blue Ltd <CCS-help@shapeblue.com>
 Build-Depends: debhelper (>= 7), openjdk-7-jdk | openjdk-8-jdk, maven3 | maven (>= 3)
 Standards-Version: 3.8.1
 Homepage: http://packages.shapeblue.com/

--- a/packaging/debian/copyright
+++ b/packaging/debian/copyright
@@ -1,1 +1,0 @@
-# Add ShapeBlue License?

--- a/resources/META-INF/cloudstack/ccs/module.properties
+++ b/resources/META-INF/cloudstack/ccs/module.properties
@@ -1,18 +1,6 @@
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
+# Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+# All Rights Reserved. The following is Source Code and is subject to all
+# restrictions on such code as contained in the End User License Agreement
+# accompanying this product.
 name=ccs
 parent=compute

--- a/resources/META-INF/cloudstack/ccs/spring-ccs-context.xml
+++ b/resources/META-INF/cloudstack/ccs/spring-ccs-context.xml
@@ -1,20 +1,8 @@
 <!--
-  Licensed to the Apache Software Foundation (ASF) under one
-  or more contributor license agreements. See the NOTICE file
-  distributed with this work for additional information
-  regarding copyright ownership. The ASF licenses this file
-  to you under the Apache License, Version 2.0 (the
-  "License"); you may not use this file except in compliance
-  with the License. You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-  Unless required by applicable law or agreed to in writing,
-  software distributed under the License is distributed on an
-  "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-  KIND, either express or implied. See the License for the
-  specific language governing permissions and limitations
-  under the License.
+ Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+ All Rights Reserved. The following is Source Code and is subject to all
+ restrictions on such code as contained in the End User License Agreement
+ accompanying this product.
 -->
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/schema/ccs-templates.sql
+++ b/schema/ccs-templates.sql
@@ -1,3 +1,8 @@
+-- Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+-- All Rights Reserved. The following is Source Code and is subject to all
+-- restrictions on such code as contained in the End User License Agreement
+-- accompanying this product.
+
 use cloud;
 
 INSERT INTO `cloud`.`vm_template` (uuid, unique_name, name, public, featured, created, state, type, hvm, bits, account_id, url, enable_password, display_text, format, guest_os_id, cross_zones, hypervisor_type, extractable)  VALUES (UUID(), 'CCS Template KVM', 'CCS Template KVM', 1, 1, now(), 'Active', 'BUILTIN', 0, 64, 1, 'http://dl.openvm.eu/cloudstack/coreos/x86_64/coreos_production_cloudstack_image-kvm.qcow2.bz2',  0, 'Cloudstack Container Service Template (KVM)', 'QCOW2', 99, 1, 'KVM',1);

--- a/schema/db/db/migration/V1.0__ccs_base_line.sql
+++ b/schema/db/db/migration/V1.0__ccs_base_line.sql
@@ -1,3 +1,7 @@
+-- Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+-- All Rights Reserved. The following is Source Code and is subject to all
+-- restrictions on such code as contained in the End User License Agreement
+-- accompanying this product.
 
 use cloud;
 

--- a/schema/delete-schema-ccs.sql
+++ b/schema/delete-schema-ccs.sql
@@ -1,3 +1,8 @@
+-- Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+-- All Rights Reserved. The following is Source Code and is subject to all
+-- restrictions on such code as contained in the End User License Agreement
+-- accompanying this product.
+
 use cloud;
 
 DROP TABLE IF EXISTS `cloud`.`sb_ccs_container_cluster_vm_map`;

--- a/scripts/install/install_apt_repo.sh
+++ b/scripts/install/install_apt_repo.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+# All Rights Reserved. The following is Source Code and is subject to all
+# restrictions on such code as contained in the End User License Agreement
+# accompanying this product.
 
 unknown_os ()
 {

--- a/scripts/install/install_yum_repo.sh
+++ b/scripts/install/install_yum_repo.sh
@@ -1,4 +1,8 @@
 #!/bin/bash
+# Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+# All Rights Reserved. The following is Source Code and is subject to all
+# restrictions on such code as contained in the End User License Agreement
+# accompanying this product.
 
 unknown_os ()
 {

--- a/scripts/setup/ccs-cleanup-database
+++ b/scripts/setup/ccs-cleanup-database
@@ -1,5 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+# All Rights Reserved. The following is Source Code and is subject to all
+# restrictions on such code as contained in the End User License Agreement
+# accompanying this product.
 
 import os
 import sys

--- a/scripts/setup/ccs-template-install
+++ b/scripts/setup/ccs-template-install
@@ -1,5 +1,9 @@
 #!/usr/bin/python
 # -*- coding: utf-8 -*-
+# Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+# All Rights Reserved. The following is Source Code and is subject to all
+# restrictions on such code as contained in the End User License Agreement
+# accompanying this product.
 
 import hashlib, hmac, string, base64, urllib
 import json, urllib

--- a/ui/plugins/ccs/ccs.css
+++ b/ui/plugins/ccs/ccs.css
@@ -1,1 +1,7 @@
+/*
+ * Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+ * All Rights Reserved. The following is Source Code and is subject to all
+ * restrictions on such code as contained in the End User License Agreement
+ * accompanying this product.
+ */
 

--- a/ui/plugins/ccs/ccs.js
+++ b/ui/plugins/ccs/ccs.js
@@ -1,3 +1,8 @@
+// Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+// All Rights Reserved. The following is Source Code and is subject to all
+// restrictions on such code as contained in the End User License Agreement
+// accompanying this product.
+
 (function (cloudStack) {
 
     var rootCaCert = "";

--- a/ui/plugins/ccs/config.js
+++ b/ui/plugins/ccs/config.js
@@ -1,3 +1,8 @@
+// Copyright (C) 2016 ShapeBlue Ltd and its licensors.
+// All Rights Reserved. The following is Source Code and is subject to all
+// restrictions on such code as contained in the End User License Agreement
+// accompanying this product.
+
 (function (cloudStack) {
   cloudStack.plugins.ccs.config = {
     title: 'Container Service',


### PR DESCRIPTION
- Adds the LICENSE file which contains the detailed license for the CCS software
- Modify the packaging contact information to be our proper legal entity -- ShapeBlue Ltd
- Adds license headers to all Python, Bash, JavaScript, and SQL scripts reserving ShapeBlue's IP rights

@gsirett please review the LICENSE file, as well as, the source headers to ensure that they are correct.
