### PR TITLE
mvp - next release

### DIFF
--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -1,16 +1,14 @@
 #cloud-config
 
 ---
+ssh_authorized_keys:
+  {{ k8s_master.ms.ssh.pub.key }}
+
 write-files:
   - path: /etc/conf.d/nfs
     permissions: '0644'
     content: |
       OPTS_RPC_MOUNTD=""
-
-  - path: /etc/kubernetes/pki/auth.csv
-    permissions: '0644'
-    content: |
-      {{ k8s_master.password }},{{ k8s_master.user }},1
 
   - path: /etc/kubernetes/pki/cloudstack/ca.crt
     permissions: '0644'
@@ -36,16 +34,16 @@ write-files:
 
       CNI_VERSION="v0.7.1"
       mkdir -p /opt/cni/bin
-      curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+      curl -L "http://172.20.0.1/files/cni/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 
       CRICTL_VERSION="v1.11.1"
       mkdir -p /opt/bin
-      curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
+      curl -L "http://172.20.0.1/files/cri-tools/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
 
       RELEASE="v1.11.4"
       mkdir -p /opt/bin
       cd /opt/bin
-      curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+      curl -L --remote-name-all http://172.20.0.1/files/k8s/${RELEASE}/{kubeadm,kubelet,kubectl}
       chmod +x {kubeadm,kubelet,kubectl}
 
       curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service
@@ -55,8 +53,7 @@ write-files:
       sysctl net.bridge.bridge-nf-call-iptables=1
 
       kubeadm config images pull
-      kubeadm init --pod-network-cidr=10.244.0.0/16 --token a4qgg6.84hjisyqzvth7yp6
-      sed -i '/allow-privileged=true/a \ \ \ \ - --basic-auth-file=/etc/kubernetes/pki/auth.csv' /etc/kubernetes/manifests/kube-apiserver.yaml
+      kubeadm init --pod-network-cidr=10.244.0.0/16 --token a4qgg6.84hjisyqzvth7yp6 {{ k8s_master.cluster.ip }}
 
   - path: /opt/bin/deploy-kube-system
     permissions: 0700

--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -49,11 +49,15 @@ write-files:
           echo "Warning: Offline install timed out!"
           break
         fi
+        set +e
         output=`blkid -o device -t TYPE=iso9660`
+        set -e
         if [ "$output" != "" ]; then
           while read -r line; do
             mkdir "${ISO_MOUNT_DIR}"
+            set +e
             mount -o ro "${line}" "${ISO_MOUNT_DIR}"
+            set -e
             if [ $? -eq 0 ]; then
               if [ -d "$BINARIES_DIR" ]; then
                 break

--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -30,30 +30,98 @@ write-files:
     owner: root:root
     content: |
       #!/bin/bash -e
+
       export PATH=$PATH:/opt/bin
 
-      CNI_VERSION="v0.7.1"
-      mkdir -p /opt/cni/bin
-      curl -L "http://172.20.0.1/files/cni/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
-
-      CRICTL_VERSION="v1.11.1"
-      mkdir -p /opt/bin
-      curl -L "http://172.20.0.1/files/cri-tools/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
-
       RELEASE="v1.11.4"
-      mkdir -p /opt/bin
-      cd /opt/bin
-      curl -L --remote-name-all http://172.20.0.1/files/k8s/${RELEASE}/{kubeadm,kubelet,kubectl}
-      chmod +x {kubeadm,kubelet,kubectl}
+      ISO_MOUNT_DIR=/mnt/k8sdisk
+      BINARIES_DIR=${ISO_MOUNT_DIR}/${RELEASE}
+      CNI_VERSION="v0.7.1"
+      CRICTL_VERSION="v1.11.1"
+      ATTEMPT_OFFLINE_INSTALL=true
+      setup_complete=false
 
-      curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service
-      mkdir -p /etc/systemd/system/kubelet.service.d
-      curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+      OFFLINE_INSTALL_ATTEMPT_SLEEP=5
+      MAX_OFFLINE_INSTALL_ATTEMPTS=36
+      offline_attempts=1
+      while true; do
+        if (( "$offline_attempts" > "$MAX_OFFLINE_INSTALL_ATTEMPTS" )); then
+          echo "Warning: Offline install timed out!"
+          break
+        fi
+        output=`blkid -o device -t TYPE=iso9660`
+        if [ "$output" != "" ]; then
+          while read -r line; do
+            mkdir "${ISO_MOUNT_DIR}"
+            mount -o ro "${line}" "${ISO_MOUNT_DIR}"
+            if [ $? -eq 0 ]; then
+              if [ -d "$BINARIES_DIR" ]; then
+                break
+              else
+                umount "${line}" && rmdir "${ISO_MOUNT_DIR}"
+              fi
+            fi
+          done <<< "$output"
+        fi
+        if [ -d "$BINARIES_DIR" ]; then
+          break
+        fi
+        echo "Waiting for Binaries directory $BINARIES_DIR to be available, sleeping for $OFFLINE_INSTALL_ATTEMPT_SLEEP seconds, attempt: $offline_attempts"
+        sleep $OFFLINE_INSTALL_ATTEMPT_SLEEP
+        offline_attempts=$[$offline_attempts + 1]
+      done
+
+      if [ -d "$BINARIES_DIR" ]; then
+        ### Binaries available offline ###
+        echo "Installing binaries from ${BINARIES_DIR}"
+        mkdir -p /opt/cni/bin
+        tar -f "${BINARIES_DIR}/cni/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" -C /opt/cni/bin -xz
+
+        mkdir -p /opt/bin
+        tar -f "${BINARIES_DIR}/cri-tools/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" -C /opt/bin -xz
+
+        mkdir -p /opt/bin
+        cd /opt/bin
+        cp -a ${BINARIES_DIR}/k8s/{kubeadm,kubelet,kubectl} /opt/bin
+        chmod +x {kubeadm,kubelet,kubectl}
+
+        sed "s:/usr/bin:/opt/bin:g" ${BINARIES_DIR}/kubelet.service > /etc/systemd/system/kubelet.service
+        mkdir -p /etc/systemd/system/kubelet.service.d
+        sed "s:/usr/bin:/opt/bin:g" ${BINARIES_DIR}/10-kubeadm.conf > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+
+        output=`ls ${BINARIES_DIR}/docker/`
+        if [ "$output" != "" ]; then
+          while read -r line; do
+            docker load < "${BINARIES_DIR}/docker/$line"
+          done <<< "$output"
+          setup_complete=true
+        fi
+        umount "${ISO_MOUNT_DIR}" && rmdir "${ISO_MOUNT_DIR}"
+      fi
+      if [ "$setup_complete" = false ]; then
+        ###  Binaries not available offline ###
+        echo "Warning: ${BINARIES_DIR} not found. Will get binaries and docker images from Internet."
+        mkdir -p /opt/cni/bin
+        curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+
+        mkdir -p /opt/bin
+        curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
+
+        mkdir -p /opt/bin
+        cd /opt/bin
+        curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+        chmod +x {kubeadm,kubelet,kubectl}
+
+        curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service
+        mkdir -p /etc/systemd/system/kubelet.service.d
+        curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+      fi
+
       systemctl enable kubelet && systemctl start kubelet
-      sysctl net.bridge.bridge-nf-call-iptables=1
+      modprobe br_netfilter && sysctl net.bridge.bridge-nf-call-iptables=1
 
       kubeadm config images pull
-      kubeadm init --pod-network-cidr=10.244.0.0/16 --token a4qgg6.84hjisyqzvth7yp6 {{ k8s_master.cluster.ip }}
+      kubeadm init --pod-network-cidr=10.244.0.0/16 --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.ip }}
 
   - path: /opt/bin/deploy-kube-system
     permissions: 0700

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -11,16 +11,16 @@ write-files:
 
       CNI_VERSION="v0.7.1"
       mkdir -p /opt/cni/bin
-      curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+      curl -L "http://172.20.0.1/files/cni/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
 
       CRICTL_VERSION="v1.11.1"
       mkdir -p /opt/bin
-      curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
+      curl -L "http://172.20.0.1/files/cri-tools/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
 
       RELEASE="v1.11.4"
       mkdir -p /opt/bin
       cd /opt/bin
-      curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+      curl -L --remote-name-all http://172.20.0.1/files/k8s/${RELEASE}/{kubeadm,kubelet,kubectl}
       chmod +x {kubeadm,kubelet,kubectl}
 
       curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -7,28 +7,96 @@ write-files:
     owner: root:root
     content: |
       #!/bin/bash -e
+      
       export PATH=$PATH:/opt/bin
 
-      CNI_VERSION="v0.7.1"
-      mkdir -p /opt/cni/bin
-      curl -L "http://172.20.0.1/files/cni/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
-
-      CRICTL_VERSION="v1.11.1"
-      mkdir -p /opt/bin
-      curl -L "http://172.20.0.1/files/cri-tools/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
-
       RELEASE="v1.11.4"
-      mkdir -p /opt/bin
-      cd /opt/bin
-      curl -L --remote-name-all http://172.20.0.1/files/k8s/${RELEASE}/{kubeadm,kubelet,kubectl}
-      chmod +x {kubeadm,kubelet,kubectl}
+      ISO_MOUNT_DIR=/mnt/k8sdisk
+      BINARIES_DIR=${ISO_MOUNT_DIR}/${RELEASE}
+      CNI_VERSION="v0.7.1"
+      CRICTL_VERSION="v1.11.1"
+      ATTEMPT_OFFLINE_INSTALL=true
+      setup_complete=false
 
-      curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service
-      mkdir -p /etc/systemd/system/kubelet.service.d
-      curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+      OFFLINE_INSTALL_ATTEMPT_SLEEP=5
+      MAX_OFFLINE_INSTALL_ATTEMPTS=36
+      offline_attempts=1
+      while true; do
+        if (( "$offline_attempts" > "$MAX_OFFLINE_INSTALL_ATTEMPTS" )); then
+          echo "Warning: Offline install timed out!"
+          break
+        fi
+        output=`blkid -o device -t TYPE=iso9660`
+        if [ "$output" != "" ]; then
+          while read -r line; do
+            mkdir "${ISO_MOUNT_DIR}"
+            mount -o ro "${line}" "${ISO_MOUNT_DIR}"
+            if [ $? -eq 0 ]; then
+              if [ -d "$BINARIES_DIR" ]; then
+                break
+              else
+                umount "${line}" && rmdir "${ISO_MOUNT_DIR}"
+              fi
+            fi
+          done <<< "$output"
+        fi
+        if [ -d "$BINARIES_DIR" ]; then
+          break
+        fi
+        echo "Waiting for Binaries directory $BINARIES_DIR to be available, sleeping for $OFFLINE_INSTALL_ATTEMPT_SLEEP seconds, attempt: $offline_attempts"
+        sleep $OFFLINE_INSTALL_ATTEMPT_SLEEP
+        offline_attempts=$[$offline_attempts + 1]
+      done
+
+      if [ -d "$BINARIES_DIR" ]; then
+        ### Binaries available offline ###
+        echo "Installing binaries from ${BINARIES_DIR}"
+        mkdir -p /opt/cni/bin
+        tar -f "${BINARIES_DIR}/cni/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" -C /opt/cni/bin -xz
+
+        mkdir -p /opt/bin
+        tar -f "${BINARIES_DIR}/cri-tools/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" -C /opt/bin -xz
+
+        mkdir -p /opt/bin
+        cd /opt/bin
+        cp -a ${BINARIES_DIR}/k8s/{kubeadm,kubelet,kubectl} /opt/bin
+        chmod +x {kubeadm,kubelet,kubectl}
+
+        sed "s:/usr/bin:/opt/bin:g" ${BINARIES_DIR}/kubelet.service > /etc/systemd/system/kubelet.service
+        mkdir -p /etc/systemd/system/kubelet.service.d
+        sed "s:/usr/bin:/opt/bin:g" ${BINARIES_DIR}/10-kubeadm.conf > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+
+        output=`ls ${BINARIES_DIR}/docker/`
+        if [ "$output" != "" ]; then
+          while read -r line; do
+            docker load < "${BINARIES_DIR}/docker/$line"
+          done <<< "$output"
+          setup_complete=true
+        fi
+        umount "${ISO_MOUNT_DIR}" && rmdir "${ISO_MOUNT_DIR}"
+      fi
+      if [ "$setup_complete" = false ]; then
+        ###  Binaries not available offline ###
+        echo "Warning: ${BINARIES_DIR} not found. Will get binaries and docker images from Internet."
+        mkdir -p /opt/cni/bin
+        curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C /opt/cni/bin -xz
+
+        mkdir -p /opt/bin
+        curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C /opt/bin -xz
+
+        mkdir -p /opt/bin
+        cd /opt/bin
+        curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+        chmod +x {kubeadm,kubelet,kubectl}
+
+        curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service
+        mkdir -p /etc/systemd/system/kubelet.service.d
+        curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" | sed "s:/usr/bin:/opt/bin:g" > /etc/systemd/system/kubelet.service.d/10-kubeadm.conf
+      fi
+
       systemctl enable kubelet && systemctl start kubelet
-      sysctl net.bridge.bridge-nf-call-iptables=1
-
+      modprobe br_netfilter && sysctl net.bridge.bridge-nf-call-iptables=1
+      
       kubeadm config images pull
 
   - path: /opt/bin/deploy-kube-system
@@ -41,7 +109,7 @@ write-files:
       modprobe ip_vs_sh
       modprobe nf_conntrack_ipv4
       export PATH=$PATH:/opt/bin
-      kubeadm join {{ k8s_master.default_ip }}:6443 --token a4qgg6.84hjisyqzvth7yp6 --discovery-token-unsafe-skip-ca-verification
+      kubeadm join {{ k8s_master.default_ip }}:6443 --token {{ k8s_master.cluster.ip }} --discovery-token-unsafe-skip-ca-verification
 
 coreos:
   units:

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -26,11 +26,15 @@ write-files:
           echo "Warning: Offline install timed out!"
           break
         fi
+        set +e
         output=`blkid -o device -t TYPE=iso9660`
+        set -e
         if [ "$output" != "" ]; then
           while read -r line; do
             mkdir "${ISO_MOUNT_DIR}"
+            set +e
             mount -o ro "${line}" "${ISO_MOUNT_DIR}"
+            set -e
             if [ $? -eq 0 ]; then
               if [ -d "$BINARIES_DIR" ]; then
                 break

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <acs.version>4.11.1.0</acs.version>
+    <acs.version>4.11.3.0-SNAPSHOT</acs.version>
 
     <cs.jpa.version>2.2.0</cs.jpa.version>
     <cs.gson.version>1.7.2</cs.gson.version>

--- a/schema/db/db/migration/V1.0__ccs_base_line.sql
+++ b/schema/db/db/migration/V1.0__ccs_base_line.sql
@@ -101,3 +101,6 @@ INSERT IGNORE INTO `cloud`.`guest_os` (id, uuid, category_id, display_name, crea
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'XenServer', 'default', 'CoreOS', 255, utc_timestamp(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'VmWare', 'default', 'coreos64Guest', 255, utc_timestamp(), 0);
 INSERT IGNORE INTO `cloud`.`guest_os_hypervisor` (uuid,hypervisor_type, hypervisor_version, guest_os_name, guest_os_id, created, is_user_defined) VALUES (UUID(),'KVM', 'default', 'CoreOS', 255, utc_timestamp(), 0);
+
+INSERT IGNORE INTO `cloud`.`configuration` VALUES ('Advanced', 'DEFAULT', 'management-server',
+'cloud.container.cluster.binaries.iso.name', 'ShapeBlue-CCS-Binaries-ISO' , 'Name of the ISO that contains k8s binaries and docker images for offline installation.', 'ShapeBlue-CCS-Binaries-ISO', NULL , NULL, 0);

--- a/schema/db/db/migration/V1.0__ccs_base_line.sql
+++ b/schema/db/db/migration/V1.0__ccs_base_line.sql
@@ -62,6 +62,7 @@ CREATE TABLE IF NOT EXISTS `cloud`.`sb_ccs_container_cluster_details` (
     `registry_password` varchar(255),
     `registry_url` varchar(255),
     `registry_email` varchar(255),
+    `kube_config_data` text COMMENT 'configuration file data of this cluster',
     `network_cleanup` tinyint unsigned NOT NULL DEFAULT 1 COMMENT 'true if network needs to be clean up on deletion of container cluster. Should be false if user specfied network for the cluster',
 
     PRIMARY KEY(`id`),

--- a/scripts/create-binaries-iso.sh
+++ b/scripts/create-binaries-iso.sh
@@ -1,0 +1,55 @@
+#!/bin/bash
+
+RELEASE="v1.11.4"
+start_dir="$PWD"
+iso_dir="${start_dir}/iso"
+working_dir="${iso_dir}/${RELEASE}"
+mkdir -p "${working_dir}"
+
+CNI_VERSION="v0.7.1"
+echo "Downloading CNI ${CNI_VERSION}..."
+cni_dir="${working_dir}/cni/${CNI_VERSION}"
+mkdir -p "${cni_dir}"
+curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C "${cni_dir}" -xz
+
+CRICTL_VERSION="v1.11.1"
+echo "Downloading CRI tools ${CRICTL_VERSION}..."
+crictl_dir="${working_dir}/cri-tools/${CRICTL_VERSION}"
+mkdir -p "${crictl_dir}"
+curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C "${crictl_dir}" -xz
+
+echo "Downloading Kubernetes tools ${RELEASE}..."
+k8s_dir="${working_dir}/k8s"
+mkdir -p "${k8s_dir}"
+cd "${k8s_dir}"
+curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
+chmod +x {kubeadm,kubelet,kubectl}
+
+echo "Downloading kubelet.service ${RELEASE}..."
+cd $start_dir
+kubelet_service_file="${working_dir}/kubelet.service"
+touch "${kubelet_service_file}"
+curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/kubelet.service" | sed "s:/usr/bin:/opt/bin:g" > ${kubelet_service_file}
+echo "Downloading 10-kubeadm.conf ${RELEASE}..."
+kubeadm_conf_file="${working_dir}/10-kubeadm.conf"
+touch "${kubeadm_conf_file}"
+curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/build/debs/10-kubeadm.conf" | sed "s:/usr/bin:/opt/bin:g" > ${kubeadm_conf_file}
+
+echo "Fetching k8s docker images..."
+docker -v
+if [ $? -ne 0 ]; then
+    sudo apt update && sudo apt install docker.io -y
+    sudo systemctl enable docker && sudo systemctl start docker
+fi
+mkdir -p "${working_dir}/docker"
+output=`${k8s_dir}/kubeadm config images list`
+while read -r line; do
+    echo "Pulling docker image $line ---"
+    sudo docker pull "$line"
+    image_name=`echo "$line" | grep -oE "[^/]+$"`
+    sudo docker save "$line" > "${working_dir}/docker/$image_name.tar"
+done <<< "$output"
+
+mkisofs -o setup.iso -J -R -l "${iso_dir}"
+
+rm -rf "${iso_dir}"

--- a/scripts/create-binaries-iso.sh
+++ b/scripts/create-binaries-iso.sh
@@ -10,20 +10,21 @@ CNI_VERSION="v0.7.1"
 echo "Downloading CNI ${CNI_VERSION}..."
 cni_dir="${working_dir}/cni/${CNI_VERSION}"
 mkdir -p "${cni_dir}"
-curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" | tar -C "${cni_dir}" -xz
+curl -L "https://github.com/containernetworking/plugins/releases/download/${CNI_VERSION}/cni-plugins-amd64-${CNI_VERSION}.tgz" -o "${cni_dir}/cni-plugins-amd64-${CNI_VERSION}.tgz"
 
 CRICTL_VERSION="v1.11.1"
 echo "Downloading CRI tools ${CRICTL_VERSION}..."
 crictl_dir="${working_dir}/cri-tools/${CRICTL_VERSION}"
 mkdir -p "${crictl_dir}"
-curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" | tar -C "${crictl_dir}" -xz
+curl -L "https://github.com/kubernetes-incubator/cri-tools/releases/download/${CRICTL_VERSION}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz" -o "${crictl_dir}/crictl-${CRICTL_VERSION}-linux-amd64.tar.gz"
 
 echo "Downloading Kubernetes tools ${RELEASE}..."
 k8s_dir="${working_dir}/k8s"
 mkdir -p "${k8s_dir}"
 cd "${k8s_dir}"
 curl -L --remote-name-all https://storage.googleapis.com/kubernetes-release/release/${RELEASE}/bin/linux/amd64/{kubeadm,kubelet,kubectl}
-chmod +x {kubeadm,kubelet,kubectl}
+kubeadm_file_permissions=`stat --format '%a' kubeadm`
+chmod +x kubeadm
 
 echo "Downloading kubelet.service ${RELEASE}..."
 cd $start_dir
@@ -38,17 +39,24 @@ curl -sSL "https://raw.githubusercontent.com/kubernetes/kubernetes/${RELEASE}/bu
 echo "Fetching k8s docker images..."
 docker -v
 if [ $? -ne 0 ]; then
+    echo "Installing docker..."
     sudo apt update && sudo apt install docker.io -y
     sudo systemctl enable docker && sudo systemctl start docker
 fi
 mkdir -p "${working_dir}/docker"
 output=`${k8s_dir}/kubeadm config images list`
 while read -r line; do
-    echo "Pulling docker image $line ---"
+    echo "Downloading docker image $line ---"
     sudo docker pull "$line"
     image_name=`echo "$line" | grep -oE "[^/]+$"`
     sudo docker save "$line" > "${working_dir}/docker/$image_name.tar"
 done <<< "$output"
+
+echo "Restore kubeadm permissions..."
+if [ "${kubeadm_file_permissions}" -eq "" ]; then
+    kubeadm_file_permissions=644
+fi
+chmod ${kubeadm_file_permissions} "${working_dir}/k8s/kubeadm"
 
 mkisofs -o setup.iso -J -R -l "${iso_dir}"
 

--- a/src/com/cloud/containercluster/CcsConfig.java
+++ b/src/com/cloud/containercluster/CcsConfig.java
@@ -24,7 +24,8 @@ public enum CcsConfig {
     ContainerClusterTemplateName("Advanced", ManagementServer.class, String.class, "cloud.container.cluster.template.name", null, "name of the template used for creating containe cluster", null, null),
     ContainerClusterMasterCloudConfig("Advanced", ManagementServer.class, String.class, "cloud.container.cluster.master.cloudconfig", null, "file location path of the cloud config used for creating       container cluster master node", null, null),
     ContainerClusterNodeCloudConfig("Advanced", ManagementServer.class, String.class, "cloud.container.cluster.node.cloudconfig", null, "file location path of the cloud config used for creating           container cluster node", null, null),
-    ContainerClusterNetworkOffering("Advanced", ManagementServer.class, String.class, "cloud.container.cluster.network.offering", null, "Name of the network offering that will be used to create           isolated network in which container cluster VMs will be launched.", null, null);
+    ContainerClusterNetworkOffering("Advanced", ManagementServer.class, String.class, "cloud.container.cluster.network.offering", null, "Name of the network offering that will be used to create           isolated network in which container cluster VMs will be launched.", null, null),
+    ContainerClusterBinariesIsoName("Advanced", ManagementServer.class, String.class, "cloud.container.cluster.binaries.iso.name", null, "Name of the ISO that contains k8s binaries and docker images for offline installation.", null, null);
 
 
     private final String _category;

--- a/src/com/cloud/containercluster/ContainerClusterDetails.java
+++ b/src/com/cloud/containercluster/ContainerClusterDetails.java
@@ -24,4 +24,5 @@ public interface ContainerClusterDetails {
     long getClusterId();
     String getUserName();
     String getPassword();
+    String getKubeConfigData();
 }

--- a/src/com/cloud/containercluster/ContainerClusterDetailsVO.java
+++ b/src/com/cloud/containercluster/ContainerClusterDetailsVO.java
@@ -84,6 +84,14 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
         this.registryEmail = registryEmail;
     }
 
+    public String getKubeConfigData() {
+        return kubeConfigData;
+    }
+
+    public void setKubeConfigData(String kubeConfigData) {
+        this.kubeConfigData = kubeConfigData;
+    }
+
     public boolean getNetworkCleanup() {
         return networkCleanup;
     }
@@ -125,6 +133,9 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
 
     @Column(name = "registry_email")
     String registryEmail;
+
+    @Column(name = "kube_config_data", length = 65535)
+    String kubeConfigData;
 
     @Column(name = "network_cleanup")
     boolean networkCleanup;

--- a/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
+++ b/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
@@ -1856,9 +1856,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         VMTemplateVO iso = _templateDao.findOneBy(sc);
         if (iso == null) {
             s_logger.warn("Binaries ISO with name :" + isoName + " specified by admin is not found.");
-            return false;
         }
-        long isoId = entityManager.findByUuid(VirtualMachineTemplate.class, "bfaa0fe5-e0a3-4a8b-803c-0c84ae6904ee").getId();
 
         List<String> services = _ntwkOfferingServiceMapDao.listServicesForNetworkOffering(networkOffering.getId());
         if (services == null || services.isEmpty() || !services.contains("SourceNat")) {

--- a/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
+++ b/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
@@ -134,6 +134,7 @@ import com.cloud.storage.VMTemplateVO;
 import com.cloud.storage.VMTemplateZoneVO;
 import com.cloud.storage.dao.VMTemplateDao;
 import com.cloud.storage.dao.VMTemplateZoneDao;
+import com.cloud.template.TemplateApiService;
 import com.cloud.template.VirtualMachineTemplate;
 import com.cloud.user.Account;
 import com.cloud.user.AccountManager;
@@ -147,6 +148,7 @@ import com.cloud.utils.component.ComponentContext;
 import com.cloud.utils.component.ManagerBase;
 import com.cloud.utils.concurrency.NamedThreadFactory;
 import com.cloud.utils.db.DbProperties;
+import com.cloud.utils.db.EntityManager;
 import com.cloud.utils.db.Filter;
 import com.cloud.utils.db.GlobalLock;
 import com.cloud.utils.db.SearchCriteria;
@@ -154,6 +156,7 @@ import com.cloud.utils.db.Transaction;
 import com.cloud.utils.db.TransactionCallback;
 import com.cloud.utils.db.TransactionCallbackWithException;
 import com.cloud.utils.db.TransactionStatus;
+import com.cloud.utils.exception.CloudRuntimeException;
 import com.cloud.utils.fsm.NoTransitionException;
 import com.cloud.utils.fsm.StateMachine2;
 import com.cloud.utils.net.Ip;
@@ -248,6 +251,10 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
     FirewallRulesDao _firewallDao;
     @Inject
     protected IpAddressManager ipAddressManager;
+    @Inject
+    public TemplateApiService templateService;
+    @Inject
+    public EntityManager entityManager;
 
     @Override
     public ContainerCluster findById(final Long id) {
@@ -277,7 +284,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             throw new InvalidParameterValueException("invalid cluster size " + clusterSize);
         }
 
-        DataCenter zone =  _dcDao.findById(zoneId);
+        DataCenter zone = _dcDao.findById(zoneId);
         if (zone == null) {
             throw new InvalidParameterValueException("Unable to find zone by id:" + zoneId);
         }
@@ -291,7 +298,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             throw new InvalidParameterValueException("No service offering with id:" + serviceOfferingId);
         }
 
-        if(sshKeyPair != null && !sshKeyPair.isEmpty()) {
+        if (sshKeyPair != null && !sshKeyPair.isEmpty()) {
             SSHKeyPairVO sshkp = _sshKeyPairDao.findByName(owner.getAccountId(), owner.getDomainId(), sshKeyPair);
             if (sshkp == null) {
                 throw new InvalidParameterValueException("Given SSH key pair with name:" + sshKeyPair + " was not found for the account " + owner.getAccountName());
@@ -324,12 +331,11 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                 if (network == null) {
                     throw new InvalidParameterValueException("Unable to find network by ID " + networkId);
                 }
-                if (!validateNetwork(network)){
+                if (!validateNetwork(network)) {
                     throw new InvalidParameterValueException("This network is not suitable for k8s cluster, network id is " + networkId);
                 }
                 _networkModel.checkNetworkPermissions(owner, network);
-            }
-            else {
+            } else {
                 throw new InvalidParameterValueException("This network is already under use by another k8s cluster, network id is " + networkId);
             }
         } else { // user has not specified network in which cluster VM's to be provisioned, so create a network for container cluster
@@ -346,8 +352,8 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
             try {
                 network = _networkMgr.createGuestNetwork(networkOffering.getId(), name + "-network", owner.getAccountName() + "-network",
-                        null, null, null, false,null, owner, null, physicalNetwork, zone.getId(), ControlledEntity.ACLType.Account, null, null, null, null, true, null, null);
-            } catch(Exception e) {
+                        null, null, null, false, null, owner, null, physicalNetwork, zone.getId(), ControlledEntity.ACLType.Account, null, null, null, null, true, null, null);
+            } catch (Exception e) {
                 s_logger.warn("Unable to create a network for the container cluster due to " + e);
                 throw new ManagementServerException("Unable to create a network for the container cluster.");
             }
@@ -440,8 +446,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         DeployDestination dest = null;
         try {
             dest = plan(containerClusterId, containerCluster.getZoneId());
-        }
-        catch (InsufficientCapacityException e){
+        } catch (InsufficientCapacityException e) {
             stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
             s_logger.warn("Provisioning the cluster failed due to insufficient capacity in the container cluster: " + containerCluster.getName() + " due to " + e);
             throw new ManagementServerException("Provisioning the cluster failed due to insufficient capacity in the container cluster: " + containerCluster.getName(), e);
@@ -457,7 +462,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
             s_logger.warn("Starting the network failed as part of starting container cluster " + containerCluster.getName() + " due to " + e);
             throw new ManagementServerException("Failed to start the network while creating container cluster name:" + containerCluster.getName(), e);
-        } catch(Exception e) {
+        } catch (Exception e) {
             stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
             s_logger.warn("Starting the network failed as part of starting container cluster " + containerCluster.getName() + " due to " + e);
             throw new ManagementServerException("Failed to start the network while creating container cluster name:" + containerCluster.getName(), e);
@@ -471,6 +476,8 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             throw new ManagementServerException("Failed to start the network while creating container cluster name:" + containerCluster.getName());
         }
         publicIp = ips.get(0);
+
+        List<Long> clusterVMIds = new ArrayList<>();
 
         UserVm k8sMasterVM = null;
         try {
@@ -488,6 +495,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             });
 
             startK8SVM(k8sMasterVM, containerCluster);
+            clusterVMIds.add(k8sMasterVM.getId());
             k8sMasterVM = _vmDao.findById(k8sMasterVM.getId());
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Provisioned the master VM's in to the container cluster name:" + containerCluster.getName());
@@ -506,7 +514,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
         long anyNodeVmId = 0;
         UserVm k8anyNodeVM = null;
-        for (int i=1; i <= containerCluster.getNodeCount(); i++) {
+        for (int i = 1; i <= containerCluster.getNodeCount(); i++) {
             UserVm vm = null;
             try {
                 vm = createK8SNode(containerCluster, masterIP, i);
@@ -520,6 +528,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                     }
                 });
                 startK8SVM(vm, containerCluster);
+                clusterVMIds.add(vm.getId());
 
                 vm = _vmDao.findById(vm.getId());
                 if (s_logger.isDebugEnabled()) {
@@ -545,7 +554,8 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             s_logger.debug("Container cluster : " + containerCluster.getName() + " VM's are successfully provisioned.");
         }
 
-        setupContainerClusterNetworkRules(publicIp, account, containerClusterId, k8sMasterVM.getId());
+        setupContainerClusterNetworkRules(publicIp, account, containerClusterId, clusterVMIds);
+        attachIsoK8SVMs(containerClusterId, clusterVMIds);
 
         int retryCounter = 0;
         int maxRetries = 30;
@@ -563,7 +573,10 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Waiting for container cluster: " + containerCluster.getName() + " API endpoint to be available. retry: " + retryCounter + "/" + maxRetries);
                 }
-                try { Thread.sleep(60000); } catch (InterruptedException ex) {}
+                try {
+                    Thread.sleep(60000);
+                } catch (InterruptedException ex) {
+                }
                 retryCounter++;
             }
         }
@@ -586,7 +599,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                             pkFile, null, "sudo cat /etc/kubernetes/admin.conf",
                             10000, 10000, 10000);
 
-                    if(result.first() && !Strings.isNullOrEmpty(result.second())) {
+                    if (result.first() && !Strings.isNullOrEmpty(result.second())) {
                         kubeConfig = result.second();
                         kubeConfig = kubeConfig.replace(String.format("server: https://%s:6443", k8sMasterVM.getPrivateIpAddress()),
                                 String.format("server: https://%s:6443", publicIp.getAddress().addr()));
@@ -623,6 +636,8 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                     containerCluster.setConsoleEndpoint("https://" + publicIp.getAddress() + ":6443/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy#!/overview?namespace=_all");
                     _containerClusterDao.update(containerCluster.getId(), containerCluster);
 
+                    detachIsoK8SVMs(containerClusterId, clusterVMIds);
+
                     if (s_logger.isDebugEnabled()) {
                         s_logger.debug("Container cluster name:" + containerCluster.getName() + " is successfully started");
                     }
@@ -630,7 +645,10 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                     return true;
                 }
 
-                try { Thread.sleep(10000);} catch (InterruptedException ex) {}
+                try {
+                    Thread.sleep(10000);
+                } catch (InterruptedException ex) {
+                }
                 retryCounter++;
             }
             s_logger.warn("Failed to setup container cluster " + containerCluster.getName() + " in usable state as" +
@@ -641,6 +659,8 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         }
 
         stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
+
+        detachIsoK8SVMs(containerClusterId, clusterVMIds);
 
         throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR,
                 "Failed to deploy container cluster: " + containerCluster.getId() + " as unable to setup up in usable state");
@@ -658,14 +678,14 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             throw new ManagementServerException("Container cluster id:" + containerClusterId + " is already deleted.");
         }
 
-        if (containerCluster.getState().equals(ContainerCluster.State.Running) ){
+        if (containerCluster.getState().equals(ContainerCluster.State.Running)) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Container cluster id: " + containerClusterId + " is already Running.");
             }
             return true;
         }
 
-        if (containerCluster.getState().equals(ContainerCluster.State.Starting) ){
+        if (containerCluster.getState().equals(ContainerCluster.State.Starting)) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Container cluster id: " + containerClusterId + " is getting started.");
             }
@@ -723,7 +743,10 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                 if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Waiting for container cluster: " + containerCluster.getName() + " API endpoint to be available. retry: " + retryCounter + "/" + maxRetries);
                 }
-                try { Thread.sleep(50000); } catch (InterruptedException ex) {}
+                try {
+                    Thread.sleep(50000);
+                } catch (InterruptedException ex) {
+                }
                 retryCounter++;
             }
         }
@@ -743,7 +766,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
     // Open up  firewall port 6443, secure port on which kubernetes API server is running. Also create portforwarding
     // rule to forward public IP traffic to master VM private IP
     private void setupContainerClusterNetworkRules(IPAddressVO publicIp, Account account, long containerClusterId,
-                                                   long masterVmId) throws  ManagementServerException {
+                                                   List<Long> clusterVMIds) throws ManagementServerException {
 
         ContainerClusterVO containerCluster = _containerClusterDao.findById(containerClusterId);
 
@@ -813,7 +836,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
             Field endPortField = rule.getClass().getDeclaredField("publicEndPort");
             endPortField.setAccessible(true);
-            endPortField.set(rule, new Integer(2222));
+            endPortField.set(rule, new Integer(2222 + clusterVMIds.size()));
 
             Field cidrField = rule.getClass().getDeclaredField("cidrlist");
             cidrField.setAccessible(true);
@@ -840,7 +863,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                     "cluster: " + containerCluster.getName());
         }
 
-        Nic masterVmNic = _networkModel.getNicInNetwork(masterVmId, containerCluster.getNetworkId());
+        Nic masterVmNic = _networkModel.getNicInNetwork(clusterVMIds.get(0), containerCluster.getNetworkId());
         // handle Nic interface method change between releases 4.5 and 4.6 and above through reflection
         Method m = null;
         try {
@@ -865,7 +888,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         final long networkId = containerCluster.getNetworkId();
         final long accountId = account.getId();
         final long domainId = account.getDomainId();
-        final long masterVmIdFinal = masterVmId;
+        final long masterVmIdFinal = clusterVMIds.get(0);
 
         try {
             PortForwardingRuleVO pfRule = Transaction.execute(new TransactionCallbackWithException<PortForwardingRuleVO, NetworkRuleConflictException>() {
@@ -890,63 +913,78 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                         " to the master VM IP :" + masterIpFinal + " in container cluster " + containerCluster.getName());
             }
         } catch (RuntimeException rte) {
-            s_logger.warn("Failed to activate port forwarding rules for the container cluster " + containerCluster.getName() + " due to "  + rte);
+            s_logger.warn("Failed to activate port forwarding rules for the container cluster " + containerCluster.getName() + " due to " + rte);
             stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
             throw new ManagementServerException("Failed to activate port forwarding rules for the cluster: " + containerCluster.getName(), rte);
         } catch (Exception e) {
-            s_logger.warn("Failed to activate port forwarding rules for the container cluster " + containerCluster.getName() + " due to "  + e);
+            s_logger.warn("Failed to activate port forwarding rules for the container cluster " + containerCluster.getName() + " due to " + e);
             stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
             throw new ManagementServerException("Failed to activate port forwarding rules for the cluster: " + containerCluster.getName(), e);
         }
 
-        try {
-            PortForwardingRuleVO pfRule = Transaction.execute(new TransactionCallbackWithException<PortForwardingRuleVO, NetworkRuleConflictException>() {
-                @Override
-                public PortForwardingRuleVO doInTransaction(TransactionStatus status) throws NetworkRuleConflictException {
-                    PortForwardingRuleVO newRule =
-                            new PortForwardingRuleVO(null, publicIpId,
-                                    2222, 2222,
-                                    masterIpFinal,
-                                    22, 22,
-                                    "tcp", networkId, accountId, domainId, masterVmIdFinal);
-                    newRule.setDisplay(true);
-                    newRule.setState(FirewallRule.State.Add);
-                    newRule = _portForwardingDao.persist(newRule);
-                    return newRule;
-                }
-            });
-            _rulesService.applyPortForwardingRules(publicIp.getId(), account);
-
-            if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Provisioning SSH port forwarding rule from port 2222 to 22 on " + publicIp.getAddress() +
-                        " to the master VM IP :" + masterIpFinal + " in container cluster " + containerCluster.getName());
+        for (int i = 0; i < clusterVMIds.size(); ++i) {
+            long vmId = clusterVMIds.get(i);
+            Nic vmNic = _networkModel.getNicInNetwork(vmId, containerCluster.getNetworkId());
+            Ip vmIp = null;
+            try {
+                vmIp = new Ip(m.invoke(vmNic).toString());
+            } catch (InvocationTargetException | IllegalAccessException ie) {
+                stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
+                throw new ManagementServerException("Failed to activate SSH port forwarding rules for the cluster: " + containerCluster.getName());
             }
-        } catch (RuntimeException rte) {
-            s_logger.warn("Failed to activate SSH port forwarding rules for the container cluster " + containerCluster.getName() + " due to "  + rte);
-            stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
-            throw new ManagementServerException("Failed to activate SSH port forwarding rules for the cluster: " + containerCluster.getName(), rte);
-        } catch (Exception e) {
-            s_logger.warn("Failed to activate SSH port forwarding rules for the container cluster " + containerCluster.getName() + " due to "  + e);
-            stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
-            throw new ManagementServerException("Failed to activate SSH port forwarding rules for the cluster: " + containerCluster.getName(), e);
+            final Ip vmIpFinal = vmIp;
+            final long vmIdFinal = vmId;
+            final int srcPortFinal = 2222 + i;
+
+            try {
+                PortForwardingRuleVO pfRule = Transaction.execute(new TransactionCallbackWithException<PortForwardingRuleVO, NetworkRuleConflictException>() {
+                    @Override
+                    public PortForwardingRuleVO doInTransaction(TransactionStatus status) throws NetworkRuleConflictException {
+                        PortForwardingRuleVO newRule =
+                                new PortForwardingRuleVO(null, publicIpId,
+                                        srcPortFinal, srcPortFinal,
+                                        vmIpFinal,
+                                        22, 22,
+                                        "tcp", networkId, accountId, domainId, vmIdFinal);
+                        newRule.setDisplay(true);
+                        newRule.setState(FirewallRule.State.Add);
+                        newRule = _portForwardingDao.persist(newRule);
+                        return newRule;
+                    }
+                });
+                _rulesService.applyPortForwardingRules(publicIp.getId(), account);
+
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Provisioning SSH port forwarding rule from port 2222 to 22 on " + publicIp.getAddress() +
+                            " to the VM IP :" + vmIpFinal + " in container cluster " + containerCluster.getName());
+                }
+            } catch (RuntimeException rte) {
+                s_logger.warn("Failed to activate SSH port forwarding rules for the container cluster " + containerCluster.getName() + " due to " + rte);
+                stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
+                throw new ManagementServerException("Failed to activate SSH port forwarding rules for the cluster: " + containerCluster.getName(), rte);
+            } catch (Exception e) {
+                s_logger.warn("Failed to activate SSH port forwarding rules for the container cluster " + containerCluster.getName() + " due to " + e);
+                stateTransitTo(containerClusterId, ContainerCluster.Event.CreateFailed);
+                throw new ManagementServerException("Failed to activate SSH port forwarding rules for the cluster: " + containerCluster.getName(), e);
+            }
         }
     }
 
     public boolean validateNetwork(Network network) {
         NetworkOffering nwkoff = _networkOfferingDao.findById(network.getNetworkOfferingId());
-        if (nwkoff.isSystemOnly()){
+        if (nwkoff.isSystemOnly()) {
             throw new InvalidParameterValueException("This network is for system use only, network id " + network.getId());
         }
-        if (! _networkModel.areServicesSupportedInNetwork(network.getId(), Service.UserData)){
+        if (!_networkModel.areServicesSupportedInNetwork(network.getId(), Service.UserData)) {
             throw new InvalidParameterValueException("This network does not support userdata that is required for k8s, network id " + network.getId());
         }
-        if (! _networkModel.areServicesSupportedInNetwork(network.getId(), Service.Firewall)){
+        if (!_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Firewall)) {
             throw new InvalidParameterValueException("This network does not support firewall that is required for k8s, network id " + network.getId());
         }
-        if (! _networkModel.areServicesSupportedInNetwork(network.getId(), Service.PortForwarding)){
+        if (!_networkModel.areServicesSupportedInNetwork(network.getId(), Service.PortForwarding)) {
             throw new InvalidParameterValueException("This network does not support port forwarding that is required for k8s, network id " + network.getId());
         }
-        if (! _networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dhcp)){
+        if (!_networkModel.areServicesSupportedInNetwork(network.getId(), Service.Dhcp)) {
             throw new InvalidParameterValueException("This network does not support dhcp that is required for k8s, network id " + network.getId());
         }
 
@@ -954,7 +992,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         IPAddressVO sourceNatIp = null;
         if (addrs.isEmpty()) {
             throw new InvalidParameterValueException("The network id:" + network.getId() + " does not have source NAT ip assoicated with it. " +
-                    "To provision a Container Cluster, a isolated network with source NAT is required." );
+                    "To provision a Container Cluster, a isolated network with source NAT is required.");
         } else {
             for (IpAddress addr : addrs) {
                 if (addr.isSourceNat()) {
@@ -963,28 +1001,28 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             }
             if (sourceNatIp == null) {
                 throw new InvalidParameterValueException("The network id:" + network.getId() + " does not have source NAT ip assoicated with it. " +
-                        "To provision a Container Cluster, a isolated network with source NAT is required." );
+                        "To provision a Container Cluster, a isolated network with source NAT is required.");
             }
         }
-        List<FirewallRuleVO> rules= _firewallDao.listByIpAndPurposeAndNotRevoked(sourceNatIp.getId(), FirewallRule.Purpose.Firewall);
+        List<FirewallRuleVO> rules = _firewallDao.listByIpAndPurposeAndNotRevoked(sourceNatIp.getId(), FirewallRule.Purpose.Firewall);
         for (FirewallRuleVO rule : rules) {
             Integer startPort = rule.getSourcePortStart();
             Integer endPort = rule.getSourcePortEnd();
             s_logger.debug("Network rule : " + startPort + " " + endPort);
             if (startPort <= 6443 && 6443 <= endPort) {
                 throw new InvalidParameterValueException("The network id:" + network.getId() + " has conflicting firewall rules to provision" +
-                        " container cluster." );
+                        " container cluster.");
             }
         }
 
-        rules= _firewallDao.listByIpAndPurposeAndNotRevoked(sourceNatIp.getId(), FirewallRule.Purpose.PortForwarding);
+        rules = _firewallDao.listByIpAndPurposeAndNotRevoked(sourceNatIp.getId(), FirewallRule.Purpose.PortForwarding);
         for (FirewallRuleVO rule : rules) {
             Integer startPort = rule.getSourcePortStart();
             Integer endPort = rule.getSourcePortEnd();
             s_logger.debug("Network rule : " + startPort + " " + endPort);
             if (startPort <= 6443 && 6443 <= endPort) {
                 throw new InvalidParameterValueException("The network id:" + network.getId() + " has conflicting port forwarding rules to provision" +
-                        " container cluster." );
+                        " container cluster.");
             }
         }
         return true;
@@ -993,25 +1031,25 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
     public boolean validateServiceOffering(ServiceOffering offering) {
         final int cpu_requested = offering.getCpu() * offering.getSpeed();
         final int ram_requested = offering.getRamSize();
-        if (offering.isDynamic()){
+        if (offering.isDynamic()) {
             throw new InvalidParameterValueException("This service offering is not suitable for k8s cluster as this is dynamic, service offering id is " + offering.getId());
         }
-        if (ram_requested < 64){
-            throw new InvalidParameterValueException("This service offering is not suitable for k8s cluster as this has less than 256M of Ram, service offering id is " +  offering.getId());
+        if (ram_requested < 64) {
+            throw new InvalidParameterValueException("This service offering is not suitable for k8s cluster as this has less than 256M of Ram, service offering id is " + offering.getId());
         }
-        if( cpu_requested < 200) {
-            throw new InvalidParameterValueException("This service offering is not suitable for k8s cluster as this has less than 600MHz of CPU, service offering id is " +  offering.getId());
+        if (cpu_requested < 200) {
+            throw new InvalidParameterValueException("This service offering is not suitable for k8s cluster as this has less than 600MHz of CPU, service offering id is " + offering.getId());
         }
         return true;
     }
 
     private void validateDockerRegistryParams(final String dockerRegistryUserName,
-                                                 final String dockerRegistryPassword,
-                                                 final String dockerRegistryUrl,
-                                                 final String dockerRegistryEmail) {
+                                              final String dockerRegistryPassword,
+                                              final String dockerRegistryUrl,
+                                              final String dockerRegistryEmail) {
         // if no params related to docker registry specified then nothing to validate so return true
         if ((dockerRegistryUserName == null || dockerRegistryUserName.isEmpty()) &&
-                (dockerRegistryPassword == null || dockerRegistryPassword.isEmpty())  &&
+                (dockerRegistryPassword == null || dockerRegistryPassword.isEmpty()) &&
                 (dockerRegistryUrl == null || dockerRegistryUrl.isEmpty()) &&
                 (dockerRegistryEmail == null || dockerRegistryEmail.isEmpty())) {
             return;
@@ -1032,7 +1070,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         }
 
         Pattern VALID_EMAIL_ADDRESS_REGEX = Pattern.compile("^[A-Z0-9._%+-]+@[A-Z0-9.-]+\\.[A-Z]{2,6}$", Pattern.CASE_INSENSITIVE);
-        Matcher matcher = VALID_EMAIL_ADDRESS_REGEX .matcher(dockerRegistryEmail);
+        Matcher matcher = VALID_EMAIL_ADDRESS_REGEX.matcher(dockerRegistryEmail);
         if (!matcher.find()) {
             throw new InvalidParameterValueException("Invalid docker registry email specified");
         }
@@ -1044,11 +1082,11 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         List<HostVO> hosts = _resourceMgr.listAllHostsInOneZoneByType(Type.Routing, dcId);
         final Map<String, Pair<HostVO, Integer>> hosts_with_resevered_capacity = new ConcurrentHashMap<String, Pair<HostVO, Integer>>();
         for (HostVO h : hosts) {
-           hosts_with_resevered_capacity.put(h.getUuid(), new Pair<HostVO, Integer>(h, 0));
+            hosts_with_resevered_capacity.put(h.getUuid(), new Pair<HostVO, Integer>(h, 0));
         }
-        boolean suitable_host_found=false;
-        for (int i=1; i <= clusterSize+1; i++) {
-            suitable_host_found=false;
+        boolean suitable_host_found = false;
+        for (int i = 1; i <= clusterSize + 1; i++) {
+            suitable_host_found = false;
             for (Map.Entry<String, Pair<HostVO, Integer>> hostEntry : hosts_with_resevered_capacity.entrySet()) {
                 Pair<HostVO, Integer> hp = hostEntry.getValue();
                 HostVO h = hp.first();
@@ -1059,11 +1097,11 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                 ClusterDetailsVO cluster_detail_ram = _clusterDetailsDao.findDetail(cluster.getId(), "memoryOvercommitRatio");
                 Float cpuOvercommitRatio = Float.parseFloat(cluster_detail_cpu.getValue());
                 Float memoryOvercommitRatio = Float.parseFloat(cluster_detail_ram.getValue());
-                if (s_logger.isDebugEnabled()){
+                if (s_logger.isDebugEnabled()) {
                     s_logger.debug("Checking host " + h.getId() + " for capacity already reserved " + reserved);
                 }
                 if (_capacityMgr.checkIfHostHasCapacity(h.getId(), cpu_requested * reserved, ram_requested * reserved, false, cpuOvercommitRatio, memoryOvercommitRatio, true)) {
-                    if (s_logger.isDebugEnabled()){
+                    if (s_logger.isDebugEnabled()) {
                         s_logger.debug("Found host " + h.getId() + " has enough capacity cpu = " + cpu_requested * reserved + " ram =" + ram_requested * reserved);
                     }
                     hostEntry.setValue(new Pair<HostVO, Integer>(h, reserved));
@@ -1071,24 +1109,23 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                     break;
                 }
             }
-            if (suitable_host_found){
+            if (suitable_host_found) {
                 continue;
-            }
-            else {
-                 if (s_logger.isDebugEnabled()){
-                     s_logger.debug("Suitable hosts not found in datacenter " + dcId + " for node " + i);
-                 }
+            } else {
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Suitable hosts not found in datacenter " + dcId + " for node " + i);
+                }
                 break;
             }
         }
-        if (suitable_host_found){
-            if (s_logger.isDebugEnabled()){
+        if (suitable_host_found) {
+            if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Suitable hosts found in datacenter " + dcId + " creating deployment destination");
             }
             return new DeployDestination(_dcDao.findById(dcId), null, null, null);
         }
         String msg = String.format("Cannot find enough capacity for container_cluster(requested cpu=%1$s memory=%2$s)",
-                cpu_requested*clusterSize, ram_requested*clusterSize);
+                cpu_requested * clusterSize, ram_requested * clusterSize);
         s_logger.warn(msg);
         throw new InsufficientServerCapacityException(msg, DataCenter.class, dcId);
     }
@@ -1097,7 +1134,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         ContainerClusterVO containerCluster = _containerClusterDao.findById(containerClusterId);
         ServiceOffering offering = _srvOfferingDao.findById(containerCluster.getServiceOfferingId());
 
-        if (s_logger.isDebugEnabled()){
+        if (s_logger.isDebugEnabled()) {
             s_logger.debug("Checking deployment destination for containerClusterId= " + containerClusterId + " in dcId=" + dcId);
         }
 
@@ -1116,14 +1153,14 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             throw new ManagementServerException("Container cluster id:" + containerClusterId + " is already deleted.");
         }
 
-        if (containerCluster.getState().equals(ContainerCluster.State.Stopped) ){
+        if (containerCluster.getState().equals(ContainerCluster.State.Stopped)) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Container cluster id: " + containerClusterId + " is already stopped.");
             }
             return true;
         }
 
-        if (containerCluster.getState().equals(ContainerCluster.State.Stopping) ){
+        if (containerCluster.getState().equals(ContainerCluster.State.Stopping)) {
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Container cluster id: " + containerClusterId + " is getting stopped.");
             }
@@ -1185,8 +1222,8 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                     10000, 10000, 10000);
             if (result.first() && !Strings.isNullOrEmpty(result.second())) {
                 String[] lines = result.second().split("\n");
-                for (String line:
-                     lines) {
+                for (String line :
+                        lines) {
                     if (line.contains(svcName) && line.contains("Running")) {
                         if (s_logger.isDebugEnabled()) {
                             s_logger.debug("Service :" + svcName + " for the container cluster "
@@ -1228,34 +1265,34 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                 || cluster.getState().equals(ContainerCluster.State.Error)
                 || cluster.getState().equals(ContainerCluster.State.Destroying))) {
             if (s_logger.isDebugEnabled()) {
-                s_logger.debug("Cannot perform delete operation on cluster:" + cluster.getName() + " in state " + cluster.getState() );
+                s_logger.debug("Cannot perform delete operation on cluster:" + cluster.getName() + " in state " + cluster.getState());
             }
-            throw new PermissionDeniedException("Cannot perform delete operation on cluster: " + cluster.getName() + " in state" + cluster.getState() );
+            throw new PermissionDeniedException("Cannot perform delete operation on cluster: " + cluster.getName() + " in state" + cluster.getState());
         }
 
         stateTransitTo(containerClusterId, ContainerCluster.Event.DestroyRequested);
 
         boolean failedVmDestroy = false;
         List<ContainerClusterVmMapVO> clusterVMs = _containerClusterVmMapDao.listByClusterId(cluster.getId());
-        if ( (clusterVMs != null) && !clusterVMs.isEmpty()) {
-            for (ContainerClusterVmMapVO clusterVM: clusterVMs) {
+        if ((clusterVMs != null) && !clusterVMs.isEmpty()) {
+            for (ContainerClusterVmMapVO clusterVM : clusterVMs) {
                 long vmID = clusterVM.getVmId();
 
                 // delete only if VM exists and is not removed
                 UserVmVO userVM = _vmDao.findById(vmID);
-                if (userVM== null || userVM.isRemoved()) {
+                if (userVM == null || userVM.isRemoved()) {
                     continue;
                 }
 
                 try {
                     UserVm vm = _userVmService.destroyVm(vmID, true);
-                    if(! VirtualMachine.State.Expunging.equals(vm.getState())) {
+                    if (!VirtualMachine.State.Expunging.equals(vm.getState())) {
                         s_logger.warn(String.format("VM '%s' with uuid '%s' should have been expunging by now but is '%s'... retrying..."
                                 , vm.getInstanceName()
                                 , vm.getUuid()
-                                , vm.getState().toString() ));
+                                , vm.getState().toString()));
                         vm = _userVmService.expungeVm(vmID);
-                        if(! VirtualMachine.State.Expunging.equals(vm.getState())) {
+                        if (!VirtualMachine.State.Expunging.equals(vm.getState())) {
                             s_logger.error(String.format("VM '%s' is now in state '%s'. I will probably fail at deleting it's cluster."
                                     , vm.getInstanceName()
                                     , vm.getState().toString()));
@@ -1265,7 +1302,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                     if (s_logger.isDebugEnabled()) {
                         s_logger.debug("Destroyed VM: " + userVM.getInstanceName() + " as part of cluster: " + cluster.getName() + " destroy.");
                     }
-                } catch (Exception e ) {
+                } catch (Exception e) {
                     failedVmDestroy = true;
                     s_logger.warn("Failed to destroy VM :" + userVM.getInstanceName() + " part of the cluster: " + cluster.getName() +
                             " due to " + e);
@@ -1277,7 +1314,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         boolean cleanupNetwork = clusterDetails.getNetworkCleanup();
 
         // if there are VM's that were not expunged, we can not delete the network
-        if(!failedVmDestroy) {
+        if (!failedVmDestroy) {
             if (cleanupNetwork) {
                 NetworkVO network = null;
                 try {
@@ -1290,13 +1327,13 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                         if (!networkDestroyed) {
                             if (s_logger.isDebugEnabled()) {
                                 s_logger.debug("Failed to destroy network: " + cluster.getNetworkId() +
-                                        " as part of cluster: " + cluster.getName()+ " destroy");
+                                        " as part of cluster: " + cluster.getName() + " destroy");
                             }
                             processFailedNetworkDelete(containerClusterId);
                             throw new ManagementServerException("Failed to delete the network as part of container cluster name:" + cluster.getName() + " clean up");
                         }
-                        if(s_logger.isDebugEnabled()) {
-                            s_logger.debug("Destroyed network: " +  network.getName() + " as part of cluster: " + cluster.getName() + " destroy");
+                        if (s_logger.isDebugEnabled()) {
+                            s_logger.debug("Destroyed network: " + network.getName() + " as part of cluster: " + cluster.getName() + " destroy");
                         }
                     }
                 } catch (Exception e) {
@@ -1356,6 +1393,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         Network.IpAddresses addrs = new Network.IpAddresses(masterIp, null);
 
         Map<String, String> customparameterMap = new HashMap<String, String>();
+        customparameterMap.put("rootdisksize", "20");
 
         String hostName = containerCluster.getName() + "-k8s-master";
 
@@ -1368,6 +1406,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             final String apiServerKey = "{{ k8s_master.apiserver.key }}";
             final String caCert = "{{ k8s_master.ca.crt }}";
             final String msSshPubKey = "{{ k8s_master.ms.ssh.pub.key }}";
+            final String clusterToken = "{{ k8s_master.cluster.token }}";
             final String clusterIp = "{{ k8s_master.cluster.ip }}";
 
 
@@ -1389,19 +1428,20 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             k8sMasterConfig = k8sMasterConfig.replace(apiServerKey, tlsPrivateKey.replace("\n", "\n      "));
             k8sMasterConfig = k8sMasterConfig.replace(caCert, tlsCaCert.replace("\n", "\n      "));
 
-            String pubKey = "- \""+_globalConfigDao.getValue("ssh.publickey")+"\"";
+            String pubKey = "- \"" + _globalConfigDao.getValue("ssh.publickey") + "\"";
 
             String sshKeyPair = containerCluster.getKeyPair();
-            if(!Strings.isNullOrEmpty(sshKeyPair)) {
+            if (!Strings.isNullOrEmpty(sshKeyPair)) {
                 SSHKeyPairVO sshkp = _sshKeyPairDao.findByName(owner.getAccountId(), owner.getDomainId(), sshKeyPair);
                 if (sshkp != null) {
-                    pubKey += "\n  - \""+sshkp.getPublicKey()+"\"";
+                    pubKey += "\n  - \"" + sshkp.getPublicKey() + "\"";
                 }
             }
             k8sMasterConfig = k8sMasterConfig.replace(msSshPubKey, pubKey);
 
+            k8sMasterConfig = k8sMasterConfig.replace(clusterToken, generateClusterToken(containerCluster));
             k8sMasterConfig = k8sMasterConfig.replace(clusterIp, String.format("--apiserver-cert-extra-sans=%s", ips.get(0).getAddress().toString()));
-        } catch (RuntimeException e ) {
+        } catch (RuntimeException e) {
             s_logger.error("Failed to read kubernetes master configuration file due to " + e);
             throw new ManagementServerException("Failed to read kubernetes master configuration file", e);
         } catch (Exception e) {
@@ -1440,6 +1480,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         Network.IpAddresses addrs = new Network.IpAddresses(null, null);
 
         Map<String, String> customparameterMap = new HashMap<String, String>();
+        customparameterMap.put("rootdisksize", "10");
 
         String hostName = containerCluster.getName() + "-k8s-node-" + String.valueOf(nodeInstance);
 
@@ -1448,8 +1489,10 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             String nodeCloudConfig = _globalConfigDao.getValue(CcsConfig.ContainerClusterNodeCloudConfig.key());
             k8sNodeConfig = readFile(nodeCloudConfig).toString();
             String masterIPString = "{{ k8s_master.default_ip }}";
+            final String clusterTokenString = "{{ k8s_master.cluster.token }}";
 
             k8sNodeConfig = k8sNodeConfig.replace(masterIPString, masterIp);
+            k8sNodeConfig = k8sNodeConfig.replace(clusterTokenString, generateClusterToken(containerCluster));
 
             ContainerClusterDetailsVO clusterDetails = _containerClusterDetailsDao.findByClusterId(containerCluster.getId());
 
@@ -1483,11 +1526,11 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                 k8sNodeConfig = k8sNodeConfig.replace(dockerAuth, "\"" + base64Auth + "\"");
                 k8sNodeConfig = k8sNodeConfig.replace(dockerEmail, "\"" + clusterDetails.getRegistryEmail() + "\"");
             }
-        } catch (RuntimeException e ) {
-            s_logger.warn("Failed to read node configuration file due to " + e );
+        } catch (RuntimeException e) {
+            s_logger.warn("Failed to read node configuration file due to " + e);
             throw new ManagementServerException("Failed to read cluster node configuration file.", e);
         } catch (Exception e) {
-            s_logger.warn("Failed to read node configuration file due to " + e );
+            s_logger.warn("Failed to read node configuration file due to " + e);
             throw new ManagementServerException("Failed to read cluster node configuration file.", e);
         }
 
@@ -1518,19 +1561,19 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
                 s_logger.debug("Started VM in the container cluster: " + containerCluster.getName());
             }
         } catch (ConcurrentOperationException ex) {
-            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: " , ex);
+            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to start VM in the container cluster name:" + containerCluster.getName(), ex);
         } catch (ResourceUnavailableException ex) {
-            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: " , ex);
+            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to start VM in the container cluster name:" + containerCluster.getName(), ex);
         } catch (InsufficientCapacityException ex) {
-            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: " , ex);
+            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to start VM in the container cluster name:" + containerCluster.getName(), ex);
         } catch (RuntimeException ex) {
-            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: " , ex);
+            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to start VM in the container cluster name:" + containerCluster.getName(), ex);
         } catch (Exception ex) {
-            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: " , ex);
+            s_logger.warn("Failed to start VM in the container cluster name:" + containerCluster.getName() + " due to Exception: ", ex);
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to start VM in the container cluster name:" + containerCluster.getName(), ex);
         }
 
@@ -1538,6 +1581,53 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         if (!startVm.getState().equals(VirtualMachine.State.Running)) {
             s_logger.warn("Failed to start VM instance.");
             throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, "Failed to start VM instance in container cluster " + containerCluster.getName());
+        }
+    }
+
+    private void attachIsoK8SVMs(long containerClusterId, List<Long> clusterVMIds) throws ServerApiException {
+        ContainerCluster containerCluster = _containerClusterDao.findById(containerClusterId);
+        String isoName = _globalConfigDao.getValue(CcsConfig.ContainerClusterBinariesIsoName.key());
+        if (isoName == null || isoName.isEmpty()) {
+            s_logger.warn("Unable to attach ISO to container cluster: " + containerCluster.getUuid() + ". Global setting " + CcsConfig.ContainerClusterBinariesIsoName.key() + " is empty.");
+            return;
+        }
+
+        SearchCriteria<VMTemplateVO> sc = _templateDao.createSearchCriteria();
+        sc.addAnd("name", SearchCriteria.Op.EQ, isoName);
+        sc.addAnd("state", SearchCriteria.Op.EQ, VMTemplateVO.State.Active.toString());
+        VMTemplateVO iso = _templateDao.findOneBy(sc);
+        if (iso == null) {
+            s_logger.warn("Unable to attach ISO to container cluster: " + containerCluster.getUuid() + ". Binaries ISO with name :" + isoName + " specified by admin is not found.");
+            return;
+        }
+        for (int i = 0; i < clusterVMIds.size(); ++i) {
+            UserVm vm = _vmDao.findById(clusterVMIds.get(i));
+            try {
+                templateService.attachIso(iso.getId(), vm.getId());
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug(String.format("Attached binaries ISO for VM: %s in cluster: %s", vm.getUuid(), containerCluster.getName()));
+                }
+            } catch (CloudRuntimeException ex) {
+                s_logger.warn(String.format("Failed to attach binaries ISO for VM: %s in the container cluster name: %s due to Exception: ", vm.getDisplayName(), containerCluster.getName()), ex);
+                // throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to attach binaries ISO for VM: %s in the container cluster name: %s", vm.getDisplayName(), containerCluster.getName()), ex);
+            }
+        }
+    }
+
+    private void detachIsoK8SVMs(long containerClusterId, List<Long> clusterVMIds) throws ServerApiException {
+        ContainerCluster containerCluster = _containerClusterDao.findById(containerClusterId);
+        for (int i = 0; i < clusterVMIds.size(); ++i) {
+            UserVm vm = _vmDao.findById(clusterVMIds.get(i));
+
+            try {
+                templateService.detachIso(vm.getId());
+                if (s_logger.isDebugEnabled()) {
+                    s_logger.debug("Started VM in the container cluster: " + containerCluster.getName());
+                }
+            } catch (CloudRuntimeException ex) {
+                s_logger.warn(String.format("Failed to detach binaries ISO for VM: %s in the container cluster name: %s due to Exception: ", vm.getDisplayName(), containerCluster.getName()), ex);
+                // throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Failed to attach binaries ISO for VM: %s in the container cluster name: %s", vm.getDisplayName(), containerCluster.getName()), ex);
+            }
         }
     }
 
@@ -1551,7 +1641,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
     }
 
     @Override
-    public ListResponse<ContainerClusterResponse>  listContainerClusters(ListContainerClusterCmd cmd) {
+    public ListResponse<ContainerClusterResponse> listContainerClusters(ListContainerClusterCmd cmd) {
 
         CallContext ctx = CallContext.current();
         Account caller = ctx.getCallingAccount();
@@ -1563,7 +1653,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
         String state = cmd.getState();
         if (state != null && !state.isEmpty()) {
-            if ( !ContainerCluster.State.Running.toString().equals(state) &&
+            if (!ContainerCluster.State.Running.toString().equals(state) &&
                     !ContainerCluster.State.Stopped.toString().equals(state) &&
                     !ContainerCluster.State.Destroyed.toString().equals(state)) {
                 throw new InvalidParameterValueException("Invalid vlaue for cluster state is specified");
@@ -1608,11 +1698,11 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
     public ContainerClusterConfigResponse getContainerClusterConfig(GetContainerClusterConfigCmd cmd) {
         ContainerClusterConfigResponse response = new ContainerClusterConfigResponse();
         ContainerCluster containerCluster = _containerClusterDao.findById(cmd.getId());
-        if (containerCluster!=null) {
+        if (containerCluster != null) {
             response.setId(containerCluster.getUuid());
             response.setName(containerCluster.getName());
             ContainerClusterDetails containerClusterDetails = _containerClusterDetailsDao.findByClusterId(containerCluster.getId());
-            if(containerClusterDetails!=null) {
+            if (containerClusterDetails != null) {
                 String configData = new java.lang.String(Base64.decodeBase64(containerClusterDetails.getKubeConfigData()));
                 response.setConfigData(configData);
             }
@@ -1669,7 +1759,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         List<String> vmIds = new ArrayList<String>();
         List<ContainerClusterVmMapVO> vmList = _containerClusterVmMapDao.listByClusterId(containerCluster.getId());
         if (vmList != null && !vmList.isEmpty()) {
-            for (ContainerClusterVmMapVO vmMapVO: vmList) {
+            for (ContainerClusterVmMapVO vmMapVO : vmList) {
                 UserVmVO userVM = _userVmDao.findById(vmMapVO.getVmId());
                 if (userVM != null) {
                     vmIds.add(userVM.getUuid());
@@ -1682,8 +1772,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         return response;
     }
 
-    static String readFile(String path) throws IOException
-    {
+    static String readFile(String path) throws IOException {
         byte[] encoded = Files.readAllBytes(Paths.get(path));
         return new String(encoded, StandardCharsets.UTF_8);
     }
@@ -1717,7 +1806,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
         final VMTemplateVO template = _templateDao.findByTemplateName(templateName);
         if (template == null) {
-           s_logger.warn("Unable to find the template:" + templateName  + " to be used for provisioning cluster");
+            s_logger.warn("Unable to find the template:" + templateName + " to be used for provisioning cluster");
             return false;
         }
 
@@ -1738,7 +1827,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
         String networkOfferingName = _globalConfigDao.getValue(CcsConfig.ContainerClusterNetworkOffering.key());
         if (networkOfferingName == null || networkOfferingName.isEmpty()) {
-            s_logger.warn("global setting " + CcsConfig.ContainerClusterNetworkOffering.key()  + " is empty. " +
+            s_logger.warn("global setting " + CcsConfig.ContainerClusterNetworkOffering.key() + " is empty. " +
                     "Admin has not yet specified the network offering to be used for provisioning isolated network for the cluster.");
             return false;
         }
@@ -1754,13 +1843,30 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             return false;
         }
 
+
+        String isoName = _globalConfigDao.getValue(CcsConfig.ContainerClusterBinariesIsoName.key());
+        if (isoName == null || isoName.isEmpty()) {
+            s_logger.warn("Global setting " + CcsConfig.ContainerClusterBinariesIsoName.key() + " is empty." +
+                    "Binaries ISO name need to be specified, for container service to install k8s binaries offline.");
+        }
+
+        SearchCriteria<VMTemplateVO> sc = _templateDao.createSearchCriteria();
+        sc.addAnd("name", SearchCriteria.Op.EQ, isoName);
+        sc.addAnd("state", SearchCriteria.Op.EQ, VMTemplateVO.State.Active.toString());
+        VMTemplateVO iso = _templateDao.findOneBy(sc);
+        if (iso == null) {
+            s_logger.warn("Binaries ISO with name :" + isoName + " specified by admin is not found.");
+            return false;
+        }
+        long isoId = entityManager.findByUuid(VirtualMachineTemplate.class, "bfaa0fe5-e0a3-4a8b-803c-0c84ae6904ee").getId();
+
         List<String> services = _ntwkOfferingServiceMapDao.listServicesForNetworkOffering(networkOffering.getId());
         if (services == null || services.isEmpty() || !services.contains("SourceNat")) {
             s_logger.warn("Network offering :" + networkOfferingName + " does not have necessary services to provision container cluster");
             return false;
         }
 
-        if (networkOffering.getEgressDefaultPolicy() == false) {
+        if (!networkOffering.getEgressDefaultPolicy()) {
             s_logger.warn("Network offering :" + networkOfferingName + "has egress default policy turned off should be on to provision container cluster.");
             return false;
         }
@@ -1809,7 +1915,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         public void reallyRun() {
             try {
                 List<ContainerClusterVO> containerClusters = _containerClusterDao.findContainerClustersToGarbageCollect();
-                for (ContainerCluster containerCluster:containerClusters ) {
+                for (ContainerCluster containerCluster : containerClusters) {
                     if (s_logger.isDebugEnabled()) {
                         s_logger.debug("Running container cluster garbage collector on container cluster name:" + containerCluster.getName());
                     }
@@ -1870,7 +1976,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
                 // run through container clusters in 'Running' state and ensure all the VM's are Running in the cluster
                 List<ContainerClusterVO> runningContainerClusters = _containerClusterDao.findContainerClustersInState(ContainerCluster.State.Running);
-                for (ContainerCluster containerCluster : runningContainerClusters ) {
+                for (ContainerCluster containerCluster : runningContainerClusters) {
                     if (s_logger.isDebugEnabled()) {
                         s_logger.debug("Running container cluster state scanner on container cluster name:" + containerCluster.getName());
                     }
@@ -1885,9 +1991,9 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
                 // run through container clusters in 'Stopped' state and ensure all the VM's are Stopped in the cluster
                 List<ContainerClusterVO> stoppedContainerClusters = _containerClusterDao.findContainerClustersInState(ContainerCluster.State.Stopped);
-                for (ContainerCluster containerCluster : stoppedContainerClusters ) {
+                for (ContainerCluster containerCluster : stoppedContainerClusters) {
                     if (s_logger.isDebugEnabled()) {
-                        s_logger.debug("Running container cluster state scanner on container cluster name:" + containerCluster.getName()+ " for state " + ContainerCluster.State.Stopped);
+                        s_logger.debug("Running container cluster state scanner on container cluster name:" + containerCluster.getName() + " for state " + ContainerCluster.State.Stopped);
                     }
                     try {
                         if (!isClusterInDesiredState(containerCluster, VirtualMachine.State.Stopped)) {
@@ -1900,7 +2006,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
 
                 // run through container clusters in 'Alert' state and reconcile state as 'Running' if the VM's are running
                 List<ContainerClusterVO> alertContainerClusters = _containerClusterDao.findContainerClustersInState(ContainerCluster.State.Alert);
-                for (ContainerCluster containerCluster : alertContainerClusters ) {
+                for (ContainerCluster containerCluster : alertContainerClusters) {
                     if (s_logger.isDebugEnabled()) {
                         s_logger.debug("Running container cluster state scanner on container cluster name:" + containerCluster.getName() + " for state " + ContainerCluster.State.Alert);
                     }
@@ -1995,5 +2101,14 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         _stateScanner = Executors.newScheduledThreadPool(1, new NamedThreadFactory("Container-Cluster-State-Scanner"));
 
         return true;
+    }
+
+    private String generateClusterToken(ContainerCluster containerCluster) {
+        if (containerCluster == null) return "";
+        String token = containerCluster.getUuid();
+        token = token.replaceAll("-", "");
+        token = token.substring(0, 22);
+        token = token.substring(0, 6) + "." + token.substring(6);
+        return token;
     }
 }

--- a/src/com/cloud/containercluster/ContainerClusterService.java
+++ b/src/com/cloud/containercluster/ContainerClusterService.java
@@ -16,15 +16,18 @@
 // under the License.
 package com.cloud.containercluster;
 
+import org.apache.cloudstack.api.command.user.containercluster.GetContainerClusterConfigCmd;
+import org.apache.cloudstack.api.command.user.containercluster.ListContainerClusterCmd;
+import org.apache.cloudstack.api.response.ContainerClusterConfigResponse;
+import org.apache.cloudstack.api.response.ContainerClusterResponse;
+import org.apache.cloudstack.api.response.ListResponse;
+
 import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.ManagementServerException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 import com.cloud.user.Account;
 import com.cloud.utils.component.PluggableService;
-import org.apache.cloudstack.api.command.user.containercluster.ListContainerClusterCmd;
-import org.apache.cloudstack.api.response.ContainerClusterResponse;
-import org.apache.cloudstack.api.response.ListResponse;
 
 public interface ContainerClusterService extends PluggableService {
 
@@ -53,6 +56,8 @@ public interface ContainerClusterService extends PluggableService {
     boolean deleteContainerCluster(Long containerClusterId) throws ManagementServerException;
 
     ListResponse<ContainerClusterResponse>  listContainerClusters(ListContainerClusterCmd cmd);
+
+    ContainerClusterConfigResponse  getContainerClusterConfig(GetContainerClusterConfigCmd cmd);
 
     ContainerClusterResponse createContainerClusterResponse(long containerClusterId);
 

--- a/src/org/apache/cloudstack/api/command/user/containercluster/GetContainerClusterConfigCmd.java
+++ b/src/org/apache/cloudstack/api/command/user/containercluster/GetContainerClusterConfigCmd.java
@@ -1,0 +1,95 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.user.containercluster;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ResponseObject;
+import org.apache.cloudstack.api.response.ContainerClusterConfigResponse;
+import org.apache.cloudstack.api.response.ContainerClusterResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.log4j.Logger;
+
+import com.cloud.containercluster.ContainerClusterService;
+import com.cloud.user.Account;
+
+
+@APICommand(name = "getContainerClusterConfig",
+        description = "Get container cluster config",
+        responseObject = ContainerClusterConfigResponse.class,
+        responseView = ResponseObject.ResponseView.Restricted,
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = true,
+        authorized = {RoleType.Admin, RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User})
+public class GetContainerClusterConfigCmd extends BaseCmd {
+
+    @Inject
+    public ContainerClusterService _containerClusterService;
+
+    public static final Logger s_logger = Logger.getLogger(GetContainerClusterConfigCmd.class.getName());
+
+    private static final String s_name = "getcontainerclusterconfigresponse";
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID,
+            entityType = ContainerClusterResponse.class,
+            description = "the ID of the container cluster")
+    private Long id;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Long getId() {
+        return id;
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+
+    @Override
+    public long getEntityOwnerId() {
+        Account account = CallContext.current().getCallingAccount();
+        if (account != null) {
+            return account.getId();
+        }
+
+        return Account.ACCOUNT_ID_SYSTEM; // no account info given, parent this command to SYSTEM so ERROR events are tracked
+    }
+
+    @Override
+    public String getCommandName() {
+        return s_name;
+    }
+
+    @Override
+    public void execute() {
+
+        ContainerClusterConfigResponse response = _containerClusterService.getContainerClusterConfig(this);
+        response.setResponseName(getCommandName());
+        setResponseObject(response);
+    }
+}

--- a/src/org/apache/cloudstack/api/command/user/containercluster/ListContainerClusterCmd.java
+++ b/src/org/apache/cloudstack/api/command/user/containercluster/ListContainerClusterCmd.java
@@ -87,7 +87,6 @@ public class ListContainerClusterCmd extends BaseListCmd {
 
     @Override
     public void execute() {
-
         ListResponse<ContainerClusterResponse> response = _containerClusterService.listContainerClusters(this);
         response.setResponseName(getCommandName());
         setResponseObject(response);

--- a/src/org/apache/cloudstack/api/response/ContainerClusterConfigResponse.java
+++ b/src/org/apache/cloudstack/api/response/ContainerClusterConfigResponse.java
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.response;
+
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.BaseResponse;
+
+import com.cloud.serializer.Param;
+import com.google.gson.annotations.SerializedName;
+
+public class ContainerClusterConfigResponse extends BaseResponse {
+    @SerializedName(ApiConstants.ID)
+    @Param(description = "the id of the container cluster")
+    private String id;
+
+    @SerializedName(ApiConstants.NAME)
+    @Param(description = "Name of the container cluster")
+    private String name;
+
+    @SerializedName("configdata")
+    @Param(description = "the config data of the cluster")
+    private String configData;
+
+    public String getId() {
+        return id;
+    }
+
+    public void setId(String id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getConfigData() {
+        return configData;
+    }
+
+    public void setConfigData(String configData) {
+        this.configData = configData;
+    }
+}

--- a/ui/plugins/ccs/ccs.js
+++ b/ui/plugins/ccs/ccs.js
@@ -520,6 +520,35 @@
                                     notification: {
                                         poll: pollAsyncJobResult
                                     }
+                                },
+                                downloadKubeConfig: {
+                                    label: 'Download Cluster Config',
+                                    compactLabel: 'label.configuration',
+                                    messages: {
+                                        notification: function(args) {
+                                            return 'Download cluster config';
+                                        }
+                                    },
+                                    action: function(args) {
+                                        var data = {
+                                            id: args.context.containerclusters[0].id
+                                        }
+                                        $.ajax({
+                                            url: createURL("getContainerClusterConfig"),
+                                            dataType: "json",
+                                            data: data,
+                                            async: false,
+                                            success: function(json) {
+                                                var jsonObj;
+                                                if (json.getcontainerclusterconfigresponse.clusterconfig != null &&
+                                                    json.getcontainerclusterconfigresponse.clusterconfig.configdata != null ) {
+                                                    jsonObj = json.getcontainerclusterconfigresponse.clusterconfig;
+                                                    clusterKubeConfig = jsonObj.configdata ;
+                                                }
+                                            }
+                                        });
+                                        downloadClusterKubeConfig();
+                                    }
                                 }
                             },
                             tabs: {
@@ -617,9 +646,10 @@
                                                     async: true,
                                                     success: function(json) {
                                                         var jsonObj;
-                                                        if (json.getcontainerclusterconfigresponse.configdata != null && json.getcontainerclusterconfigresponse.configdata > 0) {
-                                                            jsonObj = json.getcontainerclusterconfigresponse;
-                                                            clusterKubeConfig = jsonObj.configdata;
+                                                        if (json.getcontainerclusterconfigresponse.clusterconfig != null &&
+                                                            json.getcontainerclusterconfigresponse.clusterconfig.configdata != null ) {
+                                                            jsonObj = json.getcontainerclusterconfigresponse.clusterconfig;
+                                                            clusterKubeConfig = jsonObj.configdata ;
                                                             args.response.success({
                                                                 data: jsonObj
                                                             });
@@ -627,6 +657,7 @@
                                                     }
                                                 });
                                                 return jQuery('<br><p>').html("Access container cluster<br>Download Config File<br><br>How to do this<br><code>kubectl --kubeconfig /custom/path/kube.config get pods</code>");
+                                                // return jQuery('<br><p>').html("Access container cluster<br>Download Config File<br><br>How to do this<br><code>kubectl --kubeconfig /custom/path/kube.config get pods</code>");
                                             }
 
                                             return jQuery('<br><p>').html("Container cluster is not in a stable state, please check again in few minutes.");
@@ -771,6 +802,7 @@
             if (jsonObj.state == "Stopped") {
                 allowedActions.push("start");
             } else {
+                allowedActions.push("downloadKubeConfig");
                 allowedActions.push("stop");
             }
             allowedActions.push("destroy");

--- a/ui/plugins/ccs/ccs.js
+++ b/ui/plugins/ccs/ccs.js
@@ -31,6 +31,21 @@
             document.body.removeChild(elem);
         }
     };
+    var clusterKubeConfig = "";
+    var downloadClusterKubeConfig = function() {
+        var blob = new Blob([clusterKubeConfig], {type: 'text/plain'});
+        var filename = "admin.conf";
+        if(window.navigator.msSaveOrOpenBlob) {
+            window.navigator.msSaveBlob(blob, filename);
+        } else{
+            var elem = window.document.createElement('a');
+            elem.href = window.URL.createObjectURL(blob);
+            elem.download = filename;
+            document.body.appendChild(elem)
+            elem.click();
+            document.body.removeChild(elem);
+        }
+    };
     cloudStack.plugins.ccs = function(plugin) {
         plugin.ui.addSection({
             id: 'ccs',
@@ -578,76 +593,44 @@
                                     }
                                 },
                                 console : {
-                                    title: 'Dashboard',
+                                    title: 'Access',
                                     custom : function (args) {
                                         var showDashboard = function() {
-                                            var endPoint = args.context.containerclusters[0].consoleendpoint;
-                                            var username = args.context.containerclusters[0].username;
-                                            var password = args.context.containerclusters[0].password;
-                                            var protocol = endPoint.split("://")[0] + "://";
-                                            var uri = endPoint.split("://")[1];
+                                            var state = args.context.containerclusters[0].state;
 
-                                            if (!endPoint) {
+                                            if (state == "Created" || state == "Starting") { // Starting
                                                 return jQuery('<br><p>').html("Container cluster setup is under progress, please check again in few minutes.");
                                             }
 
-                                            var dashboardUrl = endPoint;
-                                            var popOut = '<p align="right"><a href="' + dashboardUrl + '" target="_blank">Pop-out ↗</a></p>';
-                                            var iframe = popOut + '<iframe src="';
-                                            var iframeArgs = '" width="950" height="560")>';
-                                            return jQuery(iframe.concat(dashboardUrl, iframeArgs));
-                                        };
+                                            if (state == "Stopped" || state == "Stopping") { // Starting
+                                                return jQuery('<br><p>').html("Container cluster setup is under progress, please check again in few minutes.");
+                                            }
 
-                                        var showNotice = function(msg) {
-                                            var msg = "The dashboard gives a GUI that allows you to deploy your containerized applications within your container clusters using Kubernetes. In order to be able to access the dashboard from your browser, you need to import the container cluster root CA certificate in your browser.";
-                                            var links = [
-                                                {name: 'Chrome on Windows', url: 'https://support.globalsign.com/customer/portal/articles/1211541-install-client-digital-certificate---windows-using-chrome'},
-                                                {name: 'Firefox on Windows', url: 'https://support.globalsign.com/customer/portal/articles/1211486-install-client-digital-certificate---firefox-for-windows'},
-                                                {name: 'IE on Windows', url: 'https://msdn.microsoft.com/en-us/library/cc750534.aspx'}
-                                            ];
-                                            var linkMessage = $('<br><br><span>').html("You may use the following links for step-by-step instructions on importing root CA certificate in following browsers:");
-                                            $.each(links, function(idx, item) {
-                                                linkMessage.append($('<br><br><a href="' + item.url + '">').html(item.name));
-                                            });
-                                            return $(
-                                                $('<span>').addClass('message').html(msg)
-                                            ).dialog({
-                                                title: "Have you installed CA certificate?",
-                                                dialogClass: args.isWarning ? 'confirm warning': 'confirm',
-                                                closeOnEscape: false,
-                                                zIndex: 5000,
-                                                buttons: [{
-                                                    text: "I've imported the certificate",
-                                                    'class': 'cancel',
-                                                    'style': 'height: 40px',
-                                                    click: function() {
-                                                        $.cookie('ccs.show.cacert.msg', '1');
-                                                        $(this).dialog('destroy');
-                                                        $('div.overlay').remove();
-                                                        $('.hovered-elem').hide();
+                                            if (state == "Running") { // Running
+                                                var data = {
+                                                    id: args.context.containerclusters[0].id
+                                                }
+                                                $.ajax({
+                                                    url: createURL("getContainerClusterConfig"),
+                                                    dataType: "json",
+                                                    data: data,
+                                                    async: true,
+                                                    success: function(json) {
+                                                        var jsonObj;
+                                                        if (json.getcontainerclusterconfigresponse.configdata != null && json.getcontainerclusterconfigresponse.configdata > 0) {
+                                                            jsonObj = json.getcontainerclusterconfigresponse;
+                                                            clusterKubeConfig = jsonObj.configdata;
+                                                            args.response.success({
+                                                                data: jsonObj
+                                                            });
+                                                        }
                                                     }
-                                                }, {
-                                                    text: "Download CA Certificate",
-                                                    'class': 'ok',
-                                                    'style': 'height: 40px',
-                                                    click: function() {
-                                                        $.ajax({
-                                                            url: createURL("listCaCertificate"),
-                                                            dataType: "json",
-                                                            async: false,
-                                                            success: function(json) {
-                                                                rootCaCert = json.listcacertificateresponse.cacertificates.certificate;
-                                                            }
-                                                        });
-                                                        downloadCaCert();
-                                                    }
-                                                }]
-                                            }).closest('.ui-dialog').overlay();
-                                        };
+                                                });
+                                                return jQuery('<br><p>').html("Access container cluster<br>Download Config File<br><br>How to do this<br><code>kubectl --kubeconfig /custom/path/kube.config get pods</code>");
+                                            }
 
-                                        if (!$.cookie('ccs.show.cacert.msg')) {
-                                          showNotice();
-                                        }
+                                            return jQuery('<br><p>').html("Container cluster is not in a stable state, please check again in few minutes.");
+                                        };
                                         return showDashboard();
                                     }
                                 },


### PR DESCRIPTION
This implements the following new functionalities and optimizations,

- Offline installation of k8s binaries and docker images.
To deploy cluster faster and more reliably, changes have been made to allow installation of k8s binaries(kubeadm, kubectl, etc.) required docker images through an ISO. An ISO with binaries can be prepared and registered with ACS. To make plugin aware about the ISO, name of ISO can be set in the globa setting` cloud.container.cluster.binaries.iso.name`. The plugin will first attempt to install binaries and images from ISO and if not found, it will continue with the online installation. This brings down cluster deployment time to nearly 5mins.

- kube-config based access
To provide more secure and reliable access to k8s cluster remotely, changes have been made to download and access Kubernetes admin.conf file for the cluster. With the help of kubectl tool and this conf file, user can connect to the cluster. `getContainerClusterConfig` API has been added for this.

- Optimizations in accessing cluster states
Code changes have been done to check running states of the cluster. Rather than using kubectl on MS to find running addon service on cluster, the plugin will make the call with k8s master itself.

- SSH access
Changes for exporting management server's SSH key to all cluster VMs.
Port forwarding rule for all the cluster VMs have been added to allow SSH access (Starting with port `2222` for master and subsequent ports for node VMs)

- Unique cluster token
Changes for using a unique token for each cluster. K8s cluster needs a toke with format <6 chars>.<16 chars>, which allows new node VMs to join the cluster. CCS Cluster's DB `UUID` has been used for this purpose.


