### PR TITLE
mvp: container cluster scaling support, stability fixes

### DIFF
--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -183,6 +183,10 @@ write-files:
     owner: root:root
     content: |
       #!/bin/bash -e
+      if [[ $(systemctl is-active setup-kube-system) != "inactive" ]]; then
+        echo "setup-kube-system is running!"
+        exit 1
+      fi
       export PATH=$PATH:/opt/bin
       export KUBECONFIG=/etc/kubernetes/admin.conf
 

--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -146,7 +146,7 @@ write-files:
           break
         fi
         set +e
-        kubeadm1 init --pod-network-cidr=10.244.0.0/16 --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.ip }}
+        kubeadm init --pod-network-cidr=10.244.0.0/16 --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.ip }}
         set -e
         if [ $? -eq 0 ]; then
           break;

--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -124,8 +124,33 @@ write-files:
       systemctl enable kubelet && systemctl start kubelet
       modprobe br_netfilter && sysctl net.bridge.bridge-nf-call-iptables=1
 
-      kubeadm config images pull
-      kubeadm init --pod-network-cidr=10.244.0.0/16 --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.ip }}
+      MAX_SETUP_CRUCIAL_CMD_ATTEMPTS=3
+      crucial_cmd_attempts=1
+      while true; do
+        if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then
+          echo "Error: kubeadm pull images failed!"
+          break
+        fi
+        set +e
+        kubeadm config images pull
+        set -e
+        if [ $? -eq 0 ]; then
+          break;
+        fi
+      done
+      crucial_cmd_attempts=1
+      while true; do
+        if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then
+          echo "Error: kubeadm init failed!"
+          break
+        fi
+        set +e
+        kubeadm init --pod-network-cidr=10.244.0.0/16 --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.ip }}
+        set -e
+        if [ $? -eq 0 ]; then
+          break;
+        fi
+      done
 
   - path: /opt/bin/deploy-kube-system
     permissions: 0700

--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -44,6 +44,8 @@ write-files:
       OFFLINE_INSTALL_ATTEMPT_SLEEP=5
       MAX_OFFLINE_INSTALL_ATTEMPTS=36
       offline_attempts=1
+      MAX_SETUP_CRUCIAL_CMD_ATTEMPTS=3
+      crucial_cmd_attempts=1
       while true; do
         if (( "$offline_attempts" > "$MAX_OFFLINE_INSTALL_ATTEMPTS" )); then
           echo "Warning: Offline install timed out!"
@@ -54,7 +56,7 @@ write-files:
         set -e
         if [ "$output" != "" ]; then
           while read -r line; do
-            if [! -d "${ISO_MOUNT_DIR}" ]; then
+            if [ ! -d "${ISO_MOUNT_DIR}" ]; then
               mkdir "${ISO_MOUNT_DIR}"
             fi
             retval=0
@@ -100,7 +102,22 @@ write-files:
         output=`ls ${BINARIES_DIR}/docker/`
         if [ "$output" != "" ]; then
           while read -r line; do
-            docker load < "${BINARIES_DIR}/docker/$line"
+            crucial_cmd_attempts=1
+            while true; do
+              if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then
+                echo "Loading docker image ${BINARIES_DIR}/docker/$line failed!"
+                break;
+              fi
+              retval=0
+              set +e
+              docker load < "${BINARIES_DIR}/docker/$line"
+              retval=$?
+              set -e
+              if [ $retval -eq 0 ]; then
+                break;
+              fi
+              crucial_cmd_attempts=$[$crucial_cmd_attempts + 1]
+            done
           done <<< "$output"
           setup_complete=true
         fi
@@ -128,7 +145,6 @@ write-files:
       systemctl enable kubelet && systemctl start kubelet
       modprobe br_netfilter && sysctl net.bridge.bridge-nf-call-iptables=1
 
-      MAX_SETUP_CRUCIAL_CMD_ATTEMPTS=3
       crucial_cmd_attempts=1
       while true; do
         if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then

--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -137,6 +137,7 @@ write-files:
         if [ $? -eq 0 ]; then
           break;
         fi
+        crucial_cmd_attempts=$[$crucial_cmd_attempts + 1]
       done
       crucial_cmd_attempts=1
       while true; do
@@ -145,11 +146,12 @@ write-files:
           break
         fi
         set +e
-        kubeadm init --pod-network-cidr=10.244.0.0/16 --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.ip }}
+        kubeadm1 init --pod-network-cidr=10.244.0.0/16 --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.ip }}
         set -e
         if [ $? -eq 0 ]; then
           break;
         fi
+        crucial_cmd_attempts=$[$crucial_cmd_attempts + 1]
       done
 
   - path: /opt/bin/deploy-kube-system

--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -54,7 +54,9 @@ write-files:
         set -e
         if [ "$output" != "" ]; then
           while read -r line; do
-            mkdir "${ISO_MOUNT_DIR}"
+            if [! -d "${ISO_MOUNT_DIR}" ]; then
+              mkdir "${ISO_MOUNT_DIR}"
+            fi
             retval=0
             set +e
             mount -o ro "${line}" "${ISO_MOUNT_DIR}"

--- a/conf/k8s-master.yml
+++ b/conf/k8s-master.yml
@@ -55,10 +55,12 @@ write-files:
         if [ "$output" != "" ]; then
           while read -r line; do
             mkdir "${ISO_MOUNT_DIR}"
+            retval=0
             set +e
             mount -o ro "${line}" "${ISO_MOUNT_DIR}"
+            retval=$?
             set -e
-            if [ $? -eq 0 ]; then
+            if [ $retval -eq 0 ]; then
               if [ -d "$BINARIES_DIR" ]; then
                 break
               else
@@ -129,12 +131,14 @@ write-files:
       while true; do
         if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then
           echo "Error: kubeadm pull images failed!"
-          break
+          exit 1
         fi
+        retval=0
         set +e
         kubeadm config images pull
+        retval=$?
         set -e
-        if [ $? -eq 0 ]; then
+        if [ $retval -eq 0 ]; then
           break;
         fi
         crucial_cmd_attempts=$[$crucial_cmd_attempts + 1]
@@ -143,12 +147,14 @@ write-files:
       while true; do
         if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then
           echo "Error: kubeadm init failed!"
-          break
+          exit 1
         fi
+        retval=0
         set +e
         kubeadm init --pod-network-cidr=10.244.0.0/16 --token {{ k8s_master.cluster.token }} {{ k8s_master.cluster.ip }}
+        retval=$?
         set -e
-        if [ $? -eq 0 ]; then
+        if [ $retval -eq 0 ]; then
           break;
         fi
         crucial_cmd_attempts=$[$crucial_cmd_attempts + 1]

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -114,6 +114,7 @@ write-files:
         if [ $? -eq 0 ]; then
           break;
         fi
+        crucial_cmd_attempts=$[$crucial_cmd_attempts + 1]
       done
 
   - path: /opt/bin/deploy-kube-system

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -100,8 +100,21 @@ write-files:
 
       systemctl enable kubelet && systemctl start kubelet
       modprobe br_netfilter && sysctl net.bridge.bridge-nf-call-iptables=1
-      
-      kubeadm config images pull
+
+      MAX_SETUP_CRUCIAL_CMD_ATTEMPTS=3
+      crucial_cmd_attempts=1
+      while true; do
+        if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then
+          echo "Error: kubeadm pull images failed!"
+          break
+        fi
+        set +e
+        kubeadm config images pull
+        set -e
+        if [ $? -eq 0 ]; then
+          break;
+        fi
+      done
 
   - path: /opt/bin/deploy-kube-system
     permissions: 0700

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -144,6 +144,10 @@ write-files:
     owner: root:root
     content: |
       #!/bin/bash -e
+      if [[ $(systemctl is-active setup-kube-system) != "inactive" ]]; then
+        echo "setup-kube-system is running!"
+        exit 1
+      fi
       modprobe ip_vs
       modprobe ip_vs_wrr
       modprobe ip_vs_sh

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -31,7 +31,9 @@ write-files:
         set -e
         if [ "$output" != "" ]; then
           while read -r line; do
-            mkdir "${ISO_MOUNT_DIR}"
+            if [! -d "${ISO_MOUNT_DIR}" ]; then
+              mkdir "${ISO_MOUNT_DIR}"
+            fi
             retval=0
             set +e
             mount -o ro "${line}" "${ISO_MOUNT_DIR}"

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -21,6 +21,8 @@ write-files:
       OFFLINE_INSTALL_ATTEMPT_SLEEP=5
       MAX_OFFLINE_INSTALL_ATTEMPTS=36
       offline_attempts=1
+      MAX_SETUP_CRUCIAL_CMD_ATTEMPTS=3
+      crucial_cmd_attempts=1
       while true; do
         if (( "$offline_attempts" > "$MAX_OFFLINE_INSTALL_ATTEMPTS" )); then
           echo "Warning: Offline install timed out!"
@@ -31,7 +33,7 @@ write-files:
         set -e
         if [ "$output" != "" ]; then
           while read -r line; do
-            if [! -d "${ISO_MOUNT_DIR}" ]; then
+            if [ ! -d "${ISO_MOUNT_DIR}" ]; then
               mkdir "${ISO_MOUNT_DIR}"
             fi
             retval=0
@@ -77,7 +79,22 @@ write-files:
         output=`ls ${BINARIES_DIR}/docker/`
         if [ "$output" != "" ]; then
           while read -r line; do
-            docker load < "${BINARIES_DIR}/docker/$line"
+            crucial_cmd_attempts=1
+            while true; do
+              if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then
+                echo "Loading docker image ${BINARIES_DIR}/docker/$line failed!"
+                break;
+              fi
+              retval=0
+              set +e
+              docker load < "${BINARIES_DIR}/docker/$line"
+              retval=$?
+              set -e
+              if [ $retval -eq 0 ]; then
+                break;
+              fi
+              crucial_cmd_attempts=$[$crucial_cmd_attempts + 1]
+            done
           done <<< "$output"
           setup_complete=true
         fi
@@ -105,7 +122,6 @@ write-files:
       systemctl enable kubelet && systemctl start kubelet
       modprobe br_netfilter && sysctl net.bridge.bridge-nf-call-iptables=1
 
-      MAX_SETUP_CRUCIAL_CMD_ATTEMPTS=3
       crucial_cmd_attempts=1
       while true; do
         if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then

--- a/conf/k8s-node.yml
+++ b/conf/k8s-node.yml
@@ -32,10 +32,12 @@ write-files:
         if [ "$output" != "" ]; then
           while read -r line; do
             mkdir "${ISO_MOUNT_DIR}"
+            retval=0
             set +e
             mount -o ro "${line}" "${ISO_MOUNT_DIR}"
+            retval=$?
             set -e
-            if [ $? -eq 0 ]; then
+            if [ $retval -eq 0 ]; then
               if [ -d "$BINARIES_DIR" ]; then
                 break
               else
@@ -106,12 +108,14 @@ write-files:
       while true; do
         if (( "$crucial_cmd_attempts" > "$MAX_SETUP_CRUCIAL_CMD_ATTEMPTS" )); then
           echo "Error: kubeadm pull images failed!"
-          break
+          exit 1
         fi
+        retval=0
         set +e
         kubeadm config images pull
+        retval=$?
         set -e
-        if [ $? -eq 0 ]; then
+        if [ $retval -eq 0 ]; then
           break;
         fi
         crucial_cmd_attempts=$[$crucial_cmd_attempts + 1]

--- a/pom.xml
+++ b/pom.xml
@@ -57,7 +57,7 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-    <acs.version>4.11.3.0-SNAPSHOT</acs.version>
+    <acs.version>4.11.4.0-SNAPSHOT</acs.version>
 
     <cs.jpa.version>2.2.0</cs.jpa.version>
     <cs.gson.version>1.7.2</cs.gson.version>

--- a/schema/db/db/migration/V1.0__ccs_base_line.sql
+++ b/schema/db/db/migration/V1.0__ccs_base_line.sql
@@ -62,6 +62,7 @@ CREATE TABLE IF NOT EXISTS `cloud`.`sb_ccs_container_cluster_details` (
     `registry_password` varchar(255),
     `registry_url` varchar(255),
     `registry_email` varchar(255),
+    `node_root_disk_size` bigint(20) unsigned DEFAULT 0 COMMENT 'root disk size of root disk for each node',
     `kube_config_data` text COMMENT 'configuration file data of this cluster',
     `network_cleanup` tinyint unsigned NOT NULL DEFAULT 1 COMMENT 'true if network needs to be clean up on deletion of container cluster. Should be false if user specfied network for the cluster',
 

--- a/src/com/cloud/containercluster/CcsEventTypes.java
+++ b/src/com/cloud/containercluster/CcsEventTypes.java
@@ -20,4 +20,5 @@ public class CcsEventTypes {
     public static final String EVENT_CONTAINER_CLUSTER_DELETE = "CONTAINER.CLUSTER.DELETE";
     public static final String EVENT_CONTAINER_CLUSTER_START = "CONTAINER.CLUSTER.START";
     public static final String EVENT_CONTAINER_CLUSTER_STOP = "CONTAINER.CLUSTER.STOP";
+    public static final String EVENT_CONTAINER_CLUSTER_SCALE = "CONTAINER.CLUSTER.SCALE";
 }

--- a/src/com/cloud/containercluster/ContainerClusterDetails.java
+++ b/src/com/cloud/containercluster/ContainerClusterDetails.java
@@ -19,10 +19,16 @@ package com.cloud.containercluster;
  * Container cluster details
  *
  */
-public interface ContainerClusterDetails {
+interface ContainerClusterDetails {
     long getId();
     long getClusterId();
     String getUserName();
     String getPassword();
+    String getRegistryUsername();
+    String getRegistryPassword();
+    String getRegistryUrl();
+    String getRegistryEmail();
+    boolean getNetworkCleanup();
+    long getNodeRootDiskSize();
     String getKubeConfigData();
 }

--- a/src/com/cloud/containercluster/ContainerClusterDetailsVO.java
+++ b/src/com/cloud/containercluster/ContainerClusterDetailsVO.java
@@ -52,6 +52,7 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
         this.clusterId = clusterId;
     }
 
+    @Override
     public String getRegistryUsername() {
         return registryUsername;
     }
@@ -60,6 +61,7 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
         this.registryUsername = registryUsername;
     }
 
+    @Override
     public String getRegistryPassword() {
         return registryPassword;
     }
@@ -68,6 +70,7 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
         this.registryPassword = registryPassword;
     }
 
+    @Override
     public String getRegistryUrl() {
         return registryUrl;
     }
@@ -76,6 +79,7 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
         this.registryUrl = registryUrl;
     }
 
+    @Override
     public String getRegistryEmail() {
         return registryEmail;
     }
@@ -84,6 +88,7 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
         this.registryEmail = registryEmail;
     }
 
+    @Override
     public String getKubeConfigData() {
         return kubeConfigData;
     }
@@ -92,6 +97,7 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
         this.kubeConfigData = kubeConfigData;
     }
 
+    @Override
     public boolean getNetworkCleanup() {
         return networkCleanup;
     }
@@ -140,6 +146,9 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
     @Column(name = "network_cleanup")
     boolean networkCleanup;
 
+    @Column(name = "node_root_disk_size")
+    long nodeRootDiskSize;
+
     public ContainerClusterDetailsVO() {
 
     }
@@ -148,5 +157,14 @@ public class ContainerClusterDetailsVO implements ContainerClusterDetails {
         this.clusterId = clusterId;
         this.username = userName;
         this.password = password;
+    }
+
+    @Override
+    public long getNodeRootDiskSize() {
+        return nodeRootDiskSize;
+    }
+
+    public void setNodeRootDiskSize(long nodeRootDiskSize) {
+        this.nodeRootDiskSize = nodeRootDiskSize;
     }
 }

--- a/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
+++ b/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
@@ -306,6 +306,13 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
         ServiceOffering serviceOffering = _srvOfferingDao.findById(serviceOfferingId);
         if (serviceOffering == null) {
             throw new InvalidParameterValueException("No service offering with id:" + serviceOfferingId);
+        } else {
+            if (serviceOffering.isDynamic()) {
+                throw new InvalidParameterValueException(String.format("Custom service offerings are not supported for creating clusters, service offering ID: %s", serviceOffering.getUuid()));
+            }
+            if (serviceOffering.getCpu() < 2 || serviceOffering.getRamSize() < 2048) {
+                throw new InvalidParameterValueException(String.format("Container cluster cannot be created with service offering ID: %s, container cluster template(CoreOS) needs minimum 2 vCPUs and 2 GB RAM", serviceOffering.getUuid()));
+            }
         }
 
         if (sshKeyPair != null && !sshKeyPair.isEmpty()) {
@@ -1840,6 +1847,13 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             serviceOffering = _srvOfferingDao.findById(serviceOfferingId);
             if (serviceOffering == null) {
                 throw new InvalidParameterValueException("Failed to find service offering id: " + serviceOfferingId);
+            } else {
+                if (serviceOffering.isDynamic()) {
+                    throw new InvalidParameterValueException(String.format("Custom service offerings are not supported for container clusters. Container cluster ID: %s, service offering ID: %s", containerCluster.getUuid(), serviceOffering.getUuid()));
+                }
+                if (serviceOffering.getCpu() < 2 || serviceOffering.getRamSize() < 2048) {
+                    throw new InvalidParameterValueException(String.format("Container cluster ID: %s cannot be scaled with service offering ID: %s, container cluster template(CoreOS) needs minimum 2 vCPUs and 2 GB RAM", containerCluster.getUuid(), serviceOffering.getUuid()));
+                }
             }
         }
 

--- a/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
+++ b/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
@@ -1800,6 +1800,10 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             throw new InvalidParameterValueException("Failed to find container cluster id: " + containerClusterId);
         }
 
+        Account caller = CallContext.current().getCallingAccount();
+
+        _accountMgr.checkAccess(caller, SecurityChecker.AccessType.OperateEntry, false, containerCluster);
+
         if (clusterSize < 1) {
             throw new InvalidParameterValueException(String.format("Container cluster id: %s cannot be scaled for size, %d",containerCluster.getUuid(), clusterSize));
         }

--- a/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
+++ b/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
@@ -1397,7 +1397,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             if (s_logger.isDebugEnabled()) {
                 s_logger.debug("Cannot perform delete operation on cluster:" + cluster.getName() + " in state " + cluster.getState());
             }
-            throw new PermissionDeniedException("Cannot perform delete operation on cluster: " + cluster.getName() + " in state" + cluster.getState());
+            throw new PermissionDeniedException("Cannot perform delete operation on cluster: " + cluster.getName() + " in state " + cluster.getState());
         }
 
         stateTransitTo(containerClusterId, ContainerCluster.Event.DestroyRequested);

--- a/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
+++ b/src/com/cloud/containercluster/ContainerClusterManagerImpl.java
@@ -1869,7 +1869,7 @@ public class ContainerClusterManagerImpl extends ManagerBase implements Containe
             }
             if (serviceOffering.getRamSize() < existingServiceOffering.getRamSize() ||
                 serviceOffering.getCpu()*serviceOffering.getSpeed() < existingServiceOffering.getCpu()*existingServiceOffering.getSpeed()) {
-                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Scaling container cluster ID: %s failed, service offering for the container cluster not found!", containerCluster.getUuid()));
+                throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR, String.format("Scaling container cluster ID: %s failed, service offering for the container cluster cannot be scaled down!", containerCluster.getUuid()));
             }
 
             // ToDo: Check capacity with new service offering at this point, how?

--- a/src/com/cloud/containercluster/ContainerClusterService.java
+++ b/src/com/cloud/containercluster/ContainerClusterService.java
@@ -16,6 +16,7 @@
 // under the License.
 package com.cloud.containercluster;
 
+import org.apache.cloudstack.api.command.user.containercluster.CreateContainerClusterCmd;
 import org.apache.cloudstack.api.command.user.containercluster.GetContainerClusterConfigCmd;
 import org.apache.cloudstack.api.command.user.containercluster.ListContainerClusterCmd;
 import org.apache.cloudstack.api.command.user.containercluster.ScaleContainerClusterCmd;
@@ -27,26 +28,13 @@ import com.cloud.exception.InsufficientCapacityException;
 import com.cloud.exception.ManagementServerException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
-import com.cloud.user.Account;
 import com.cloud.utils.component.PluggableService;
 
 public interface ContainerClusterService extends PluggableService {
 
     ContainerCluster findById(final Long id);
 
-    ContainerCluster createContainerCluster(String name,
-                                            String displayName,
-                                            Long zoneId,
-                                            Long serviceOffering,
-                                            Account owner,
-                                            Long networkId,
-                                            String sshKeyPair,
-                                            Long nodeCount,
-                                            String dockerRegistryUsername,
-                                            String dockerRegistryPassword,
-                                            String dockerRegistryUrl,
-                                            String dockerRegistryEmail
-                                            ) throws InsufficientCapacityException,
+    ContainerCluster createContainerCluster(CreateContainerClusterCmd cmd) throws InsufficientCapacityException,
                      ResourceAllocationException, ManagementServerException;
 
     boolean startContainerCluster(long containerClusterId, boolean onCreate) throws ManagementServerException,

--- a/src/com/cloud/containercluster/ContainerClusterService.java
+++ b/src/com/cloud/containercluster/ContainerClusterService.java
@@ -18,6 +18,7 @@ package com.cloud.containercluster;
 
 import org.apache.cloudstack.api.command.user.containercluster.GetContainerClusterConfigCmd;
 import org.apache.cloudstack.api.command.user.containercluster.ListContainerClusterCmd;
+import org.apache.cloudstack.api.command.user.containercluster.ScaleContainerClusterCmd;
 import org.apache.cloudstack.api.response.ContainerClusterConfigResponse;
 import org.apache.cloudstack.api.response.ContainerClusterResponse;
 import org.apache.cloudstack.api.response.ListResponse;
@@ -55,10 +56,13 @@ public interface ContainerClusterService extends PluggableService {
 
     boolean deleteContainerCluster(Long containerClusterId) throws ManagementServerException;
 
-    ListResponse<ContainerClusterResponse>  listContainerClusters(ListContainerClusterCmd cmd);
+    ListResponse<ContainerClusterResponse> listContainerClusters(ListContainerClusterCmd cmd);
 
-    ContainerClusterConfigResponse  getContainerClusterConfig(GetContainerClusterConfigCmd cmd);
+    ContainerClusterConfigResponse getContainerClusterConfig(GetContainerClusterConfigCmd cmd);
 
     ContainerClusterResponse createContainerClusterResponse(long containerClusterId);
+
+    boolean scaleContainerCluster(ScaleContainerClusterCmd cmd) throws ManagementServerException,
+            ResourceAllocationException, ResourceUnavailableException, InsufficientCapacityException;
 
 }

--- a/src/org/apache/cloudstack/api/CcsApiConstants.java
+++ b/src/org/apache/cloudstack/api/CcsApiConstants.java
@@ -21,4 +21,5 @@ public class CcsApiConstants {
     public static final String DOCKER_REGISTRY_PASSWORD = "dockerregistrypassword";
     public static final String DOCKER_REGISTRY_URL = "dockerregistryurl";
     public static final String DOCKER_REGISTRY_EMAIL = "dockerregistryemail";
+    public static final String NODE_ROOT_DISK_SIZE = "noderootdisksize";
 }

--- a/src/org/apache/cloudstack/api/command/user/containercluster/CreateContainerClusterCmd.java
+++ b/src/org/apache/cloudstack/api/command/user/containercluster/CreateContainerClusterCmd.java
@@ -17,15 +17,6 @@ package org.apache.cloudstack.api.command.user.containercluster;
 
 import javax.inject.Inject;
 
-import com.cloud.containercluster.ContainerCluster;
-import com.cloud.containercluster.ContainerClusterService;
-import com.cloud.containercluster.CcsEventTypes;
-import com.cloud.exception.InsufficientCapacityException;
-import com.cloud.exception.ResourceAllocationException;
-import com.cloud.exception.ManagementServerException;
-import com.cloud.exception.ConcurrentOperationException;
-import com.cloud.exception.ResourceUnavailableException;
-import com.cloud.user.Account;
 import org.apache.cloudstack.acl.RoleType;
 import org.apache.cloudstack.acl.SecurityChecker.AccessType;
 import org.apache.cloudstack.api.ACL;
@@ -38,14 +29,24 @@ import org.apache.cloudstack.api.CcsApiConstants;
 import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ResponseObject.ResponseView;
 import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.ContainerClusterResponse;
 import org.apache.cloudstack.api.response.DomainResponse;
 import org.apache.cloudstack.api.response.NetworkResponse;
 import org.apache.cloudstack.api.response.ProjectResponse;
 import org.apache.cloudstack.api.response.ServiceOfferingResponse;
-import org.apache.cloudstack.api.response.ContainerClusterResponse;
 import org.apache.cloudstack.api.response.ZoneResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.log4j.Logger;
+
+import com.cloud.containercluster.CcsEventTypes;
+import com.cloud.containercluster.ContainerCluster;
+import com.cloud.containercluster.ContainerClusterService;
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.ManagementServerException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+import com.cloud.user.Account;
 
 @APICommand(name = "createContainerCluster",
         description = "Creates a cluster of VM's for launching containers.",
@@ -126,6 +127,10 @@ public class CreateContainerClusterCmd extends BaseAsyncCreateCmd {
             description = "email of the docker image private registry user")
     private String dockerRegistryEmail;
 
+    @Parameter(name = CcsApiConstants.NODE_ROOT_DISK_SIZE, type = CommandType.LONG,
+            description = "root disk size of root disk for each node")
+    private Long nodeRootDiskSize;
+
     /////////////////////////////////////////////////////
     /////////////////// Accessors ///////////////////////
     /////////////////////////////////////////////////////
@@ -164,6 +169,30 @@ public class CreateContainerClusterCmd extends BaseAsyncCreateCmd {
 
     public String getSSHKeyPairName() {
         return sshKeyPairName;
+    }
+
+    public Long getClusterSize() {
+        return clusterSize;
+    }
+
+    public String getDockerRegistryUserName() {
+        return dockerRegistryUserName;
+    }
+
+    public String getDockerRegistryPassword() {
+        return dockerRegistryPassword;
+    }
+
+    public String getDockerRegistryUrl() {
+        return dockerRegistryUrl;
+    }
+
+    public String getDockerRegistryEmail() {
+        return dockerRegistryEmail;
+    }
+
+    public Long getNodeRootDiskSize() {
+        return nodeRootDiskSize;
     }
 
     @Inject
@@ -253,9 +282,7 @@ public class CreateContainerClusterCmd extends BaseAsyncCreateCmd {
 
             Account owner = _accountService.getActiveAccountById(getEntityOwnerId());
 
-            ContainerCluster cluster = _containerClusterService.createContainerCluster(name,
-                    description, zoneId, serviceOfferingId, owner, networkId, sshKeyPairName, clusterSize,
-                    dockerRegistryUserName, dockerRegistryPassword, dockerRegistryUrl, dockerRegistryEmail);
+            ContainerCluster cluster = _containerClusterService.createContainerCluster(this);
 
             if (cluster != null) {
                 setEntityId(cluster.getId());

--- a/src/org/apache/cloudstack/api/command/user/containercluster/ScaleContainerClusterCmd.java
+++ b/src/org/apache/cloudstack/api/command/user/containercluster/ScaleContainerClusterCmd.java
@@ -1,0 +1,132 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+
+package org.apache.cloudstack.api.command.user.containercluster;
+
+import javax.inject.Inject;
+
+import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.api.APICommand;
+import org.apache.cloudstack.api.ApiConstants;
+import org.apache.cloudstack.api.ApiErrorCode;
+import org.apache.cloudstack.api.BaseAsyncCmd;
+import org.apache.cloudstack.api.Parameter;
+import org.apache.cloudstack.api.ResponseObject;
+import org.apache.cloudstack.api.ServerApiException;
+import org.apache.cloudstack.api.response.ContainerClusterResponse;
+import org.apache.cloudstack.context.CallContext;
+import org.apache.log4j.Logger;
+
+import com.cloud.containercluster.CcsEventTypes;
+import com.cloud.containercluster.ContainerCluster;
+import com.cloud.containercluster.ContainerClusterService;
+import com.cloud.exception.ConcurrentOperationException;
+import com.cloud.exception.InsufficientCapacityException;
+import com.cloud.exception.ManagementServerException;
+import com.cloud.exception.NetworkRuleConflictException;
+import com.cloud.exception.ResourceAllocationException;
+import com.cloud.exception.ResourceUnavailableException;
+
+@APICommand(name = ScaleContainerClusterCmd.APINAME, description = "Scales a running or stopped container cluster",
+        responseObject = ContainerClusterResponse.class,
+        responseView = ResponseObject.ResponseView.Restricted,
+        entityType = {ContainerCluster.class},
+        requestHasSensitiveInfo = false,
+        responseHasSensitiveInfo = true,
+        authorized = {RoleType.Admin, RoleType.ResourceAdmin, RoleType.DomainAdmin, RoleType.User})
+public class ScaleContainerClusterCmd extends BaseAsyncCmd {
+
+    public static final Logger s_logger = Logger.getLogger(StartContainerClusterCmd.class.getName());
+
+    public static final String APINAME = "scaleContainerCluster";
+
+    @Inject
+    public ContainerClusterService containerClusterService;
+
+    /////////////////////////////////////////////////////
+    //////////////// API parameters /////////////////////
+    /////////////////////////////////////////////////////
+    @Parameter(name = ApiConstants.ID, type = CommandType.UUID,
+            entityType = ContainerClusterResponse.class,
+            description = "the ID of the container cluster")
+    private Long id;
+
+    @Parameter(name=ApiConstants.SIZE, type = CommandType.LONG,
+            required = true, description = "number of container cluster nodes")
+    private Long clusterSize;
+
+    /////////////////////////////////////////////////////
+    /////////////////// Accessors ///////////////////////
+    /////////////////////////////////////////////////////
+
+    public Long getId() {
+        return id;
+    }
+
+    public Long getClusterSize() {
+        return clusterSize;
+    }
+
+    @Override
+    public String getEventType() {
+        return CcsEventTypes.EVENT_CONTAINER_CLUSTER_SCALE;
+    }
+
+    @Override
+    public String getEventDescription() {
+        return "Scaling container cluster id: " + getId();
+    }
+
+    @Override
+    public String getCommandName() {
+        return APINAME.toLowerCase() + "response";
+    }
+
+    @Override
+    public long getEntityOwnerId() {
+        return CallContext.current().getCallingAccount().getId();
+    }
+
+    /////////////////////////////////////////////////////
+    /////////////// API Implementation///////////////////
+    /////////////////////////////////////////////////////
+    public ContainerCluster validateRequest() {
+        if (getId() == null || getId() < 1L) {
+            throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Invalid container cluster ID provided");
+        }
+        final ContainerCluster containerCluster = containerClusterService.findById(getId());
+        if (containerCluster == null) {
+            throw new ServerApiException(ApiErrorCode.PARAM_ERROR, "Given container cluster was not found");
+        }
+        return containerCluster;
+    }
+
+    @Override
+    public void execute() throws ResourceUnavailableException, InsufficientCapacityException, ServerApiException, ConcurrentOperationException, ResourceAllocationException, NetworkRuleConflictException {
+        final ContainerCluster containerCluster = validateRequest();
+        try {
+            containerClusterService.scaleContainerCluster(this);
+            final ContainerClusterResponse response = containerClusterService.createContainerClusterResponse(getId());
+            response.setResponseName(getCommandName());
+            setResponseObject(response);
+        } catch (InsufficientCapacityException | ResourceUnavailableException | ManagementServerException ex) {
+            s_logger.warn("Failed to scale container cluster:" + containerCluster.getUuid() + " due to " + ex.getMessage());
+            throw new ServerApiException(ApiErrorCode.INTERNAL_ERROR,
+                    "Failed to scale container cluster:" + containerCluster.getUuid(), ex);
+        }
+    }
+}

--- a/src/org/apache/cloudstack/api/command/user/containercluster/ScaleContainerClusterCmd.java
+++ b/src/org/apache/cloudstack/api/command/user/containercluster/ScaleContainerClusterCmd.java
@@ -20,6 +20,8 @@ package org.apache.cloudstack.api.command.user.containercluster;
 import javax.inject.Inject;
 
 import org.apache.cloudstack.acl.RoleType;
+import org.apache.cloudstack.acl.SecurityChecker;
+import org.apache.cloudstack.api.ACL;
 import org.apache.cloudstack.api.APICommand;
 import org.apache.cloudstack.api.ApiConstants;
 import org.apache.cloudstack.api.ApiErrorCode;
@@ -28,6 +30,7 @@ import org.apache.cloudstack.api.Parameter;
 import org.apache.cloudstack.api.ResponseObject;
 import org.apache.cloudstack.api.ServerApiException;
 import org.apache.cloudstack.api.response.ContainerClusterResponse;
+import org.apache.cloudstack.api.response.ServiceOfferingResponse;
 import org.apache.cloudstack.context.CallContext;
 import org.apache.log4j.Logger;
 
@@ -65,8 +68,13 @@ public class ScaleContainerClusterCmd extends BaseAsyncCmd {
             description = "the ID of the container cluster")
     private Long id;
 
+    @ACL(accessType = SecurityChecker.AccessType.UseEntry)
+    @Parameter(name = ApiConstants.SERVICE_OFFERING_ID, type = CommandType.UUID, entityType = ServiceOfferingResponse.class,
+            description = "the ID of the service offering for the virtual machines in the cluster.")
+    private Long serviceOfferingId;
+
     @Parameter(name=ApiConstants.SIZE, type = CommandType.LONG,
-            required = true, description = "number of container cluster nodes")
+            description = "number of container cluster nodes")
     private Long clusterSize;
 
     /////////////////////////////////////////////////////
@@ -75,6 +83,10 @@ public class ScaleContainerClusterCmd extends BaseAsyncCmd {
 
     public Long getId() {
         return id;
+    }
+
+    public Long getServiceOfferingId() {
+        return serviceOfferingId;
     }
 
     public Long getClusterSize() {

--- a/src/org/apache/cloudstack/api/command/user/containercluster/ScaleContainerClusterCmd.java
+++ b/src/org/apache/cloudstack/api/command/user/containercluster/ScaleContainerClusterCmd.java
@@ -41,7 +41,7 @@ import com.cloud.exception.NetworkRuleConflictException;
 import com.cloud.exception.ResourceAllocationException;
 import com.cloud.exception.ResourceUnavailableException;
 
-@APICommand(name = ScaleContainerClusterCmd.APINAME, description = "Scales a running or stopped container cluster",
+@APICommand(name = ScaleContainerClusterCmd.APINAME, description = "Scales a created or running container cluster",
         responseObject = ContainerClusterResponse.class,
         responseView = ResponseObject.ResponseView.Restricted,
         entityType = {ContainerCluster.class},

--- a/ui/plugins/ccs/ccs.css
+++ b/ui/plugins/ccs/ccs.css
@@ -13,3 +13,20 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+.downloadContainerClusterKubeConfig .icon {
+  background-position: -35px -125px;
+}
+
+.downloadContainerClusterKubeConfig:hover .icon {
+  background-position: -35px -707px;
+}
+
+.scaleContainerCluster .icon {
+  background-position: -264px -2px;
+}
+
+.scaleContainerCluster:hover .icon {
+  background-position: -263px -583px;
+}
+

--- a/ui/plugins/ccs/ccs.js
+++ b/ui/plugins/ccs/ccs.js
@@ -547,6 +547,12 @@
                                             }
                                         });
                                         downloadClusterKubeConfig();
+                                        args.response.success({});
+                                    },
+                                    notification: {
+                                        poll: function(args) {
+                                            args.complete();
+                                        }
                                     }
                                 },
                                 scaleContainerCluster: {
@@ -702,7 +708,7 @@
                                                         }
                                                     }
                                                 });
-                                                return jQuery('<br><p>').html("Access container cluster<br>Download Config File<br><br>How to do this<br><code>kubectl --kubeconfig /custom/path/kube.config get pods</code>");
+                                                return jQuery('<br><p>').html("Access container cluster<br>Download Config File<br><br>Use kubectl<br><code>kubectl --kubeconfig /custom/path/kube.config {COMMAND}</code><br><br>List pods<br><code>kubectl --kubeconfig /custom/path/kube.config get pods --all-namespaces</code><br>Access dashboard web UI<br>Run proxy locally<br><code>kubectl --kubeconfig /custom/path/kube.config proxy</code><br>Open URL in browser<br><code>http://localhost:8001/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy/</code>");
                                                 // return jQuery('<br><p>').html("Access container cluster<br>Download Config File<br><br>How to do this<br><code>kubectl --kubeconfig /custom/path/kube.config get pods</code>");
                                             }
 

--- a/ui/plugins/ccs/ccs.js
+++ b/ui/plugins/ccs/ccs.js
@@ -521,12 +521,11 @@
                                         poll: pollAsyncJobResult
                                     }
                                 },
-                                downloadKubeConfig: {
-                                    label: 'Download Cluster Config',
-                                    compactLabel: 'label.configuration',
+                                downloadContainerClusterKubeConfig: {
+                                    label: 'Download Container Cluster Config',
                                     messages: {
                                         notification: function(args) {
-                                            return 'Download cluster config';
+                                            return 'Download Container Cluster Config';
                                         }
                                     },
                                     action: function(args) {
@@ -548,6 +547,53 @@
                                             }
                                         });
                                         downloadClusterKubeConfig();
+                                    }
+                                },
+                                scaleContainerCluster: {
+                                    label: 'Scale Container Cluster',
+                                    messages: {
+                                        notification: function(args) {
+                                            return 'Scale Container Cluster';
+                                        }
+                                    },
+                                    createForm: {
+                                        title: 'Scale Container Cluster',
+                                        desc: '',
+                                        fields: {
+                                            size: {
+                                                label: 'Cluster size',
+                                                //docID: 'helpContainerClusterSize',
+                                                validation: {
+                                                    required: true,
+                                                    number: true
+                                                },
+                                            }
+                                        }
+                                    },
+                                    action: function(args) {
+                                        var data = {
+                                            id: args.context.containerclusters[0].id,
+                                            size: args.data.size
+                                        };
+                                        $.ajax({
+                                            url: createURL('scaleContainerCluster'),
+                                            data: data,
+                                            dataType: "json",
+                                            success: function (json) {
+                                                var jid = json.scalecontainerclusterresponse.jobid;
+                                                args.response.success({
+                                                    _custom: {
+                                                        jobId: jid,
+                                                        getActionFilter: function() {
+                                                            return ccsActionfilter;
+                                                        }
+                                                    }
+                                                });
+                                            }
+                                        }); //end ajax
+                                    },
+                                    notification: {
+                                        poll: pollAsyncJobResult
                                     }
                                 }
                             },
@@ -802,8 +848,11 @@
             if (jsonObj.state == "Stopped") {
                 allowedActions.push("start");
             } else {
-                allowedActions.push("downloadKubeConfig");
+                allowedActions.push("downloadContainerClusterKubeConfig");
                 allowedActions.push("stop");
+            }
+            if (jsonObj.state == "Created" || jsonObj.state == "Running") {
+                allowedActions.push("scaleContainerCluster");
             }
             allowedActions.push("destroy");
         }

--- a/ui/plugins/ccs/ccs.js
+++ b/ui/plugins/ccs/ccs.js
@@ -565,7 +565,44 @@
                                     createForm: {
                                         title: 'Scale Container Cluster',
                                         desc: '',
+                                        preFilter: function(args) {
+                                            var options = args.$form.find('.form-item[rel=serviceoffering]').find('option');
+                                            $.each(options, function(optionIndex, option) {
+                                                if ($(option).val() === args.context.containerclusters[0].serviceofferingid) {
+                                                    $(option).attr('selected','selected');
+                                                }
+                                            });
+                                        },
                                         fields: {
+                                            serviceoffering: {
+                                                label: 'label.menu.service.offerings',
+                                                //docID: 'helpContainerClusterServiceOffering',
+                                                validation: {
+                                                    required: true
+                                                },
+                                                select: function(args) {
+                                                    $.ajax({
+                                                        url: createURL("listServiceOfferings"),
+                                                        dataType: "json",
+                                                        async: true,
+                                                        success: function(json) {
+                                                            var offeringObjs = [];
+                                                            var items = json.listserviceofferingsresponse.serviceoffering;
+                                                            if (items != null) {
+                                                                for (var i = 0; i < items.length; i++) {
+                                                                    offeringObjs.push({
+                                                                        id: items[i].id,
+                                                                        description: items[i].name
+                                                                    });
+                                                                }
+                                                            }
+                                                            args.response.success({
+                                                                data: offeringObjs
+                                                            });
+                                                        }
+                                                    });
+                                                }
+                                            },
                                             size: {
                                                 label: 'Cluster size',
                                                 //docID: 'helpContainerClusterSize',
@@ -579,6 +616,7 @@
                                     action: function(args) {
                                         var data = {
                                             id: args.context.containerclusters[0].id,
+                                            serviceofferingid: args.data.serviceoffering,
                                             size: args.data.size
                                         };
                                         $.ajax({

--- a/ui/plugins/ccs/ccs.js
+++ b/ui/plugins/ccs/ccs.js
@@ -206,6 +206,14 @@
                                                 });
                                             }
                                         },
+                                        noderootdisksize: {
+                                            label: 'Node root disk size (in GB)',
+                                            //docID: 'helpContainerClusterNodeRootDiskSize',
+                                            validation: {
+                                                required: true,
+                                                number: true
+                                            }
+                                        },
                                         network: {
                                             label: 'label.network',
                                             //docID: 'helpContainerClusterNetwork',
@@ -321,7 +329,8 @@
                                         zoneid: args.data.zone,
                                         serviceofferingid: args.data.serviceoffering,
                                         size: args.data.size,
-                                        keypair: args.data.sshkeypair
+                                        keypair: args.data.sshkeypair,
+                                        noderootdisksize: args.data.noderootdisksize
                                     };
 
                                     if (args.data.supportPrivateRegistry) {

--- a/ui/plugins/ccs/ccs.js
+++ b/ui/plugins/ccs/ccs.js
@@ -210,7 +210,6 @@
                                             label: 'Node root disk size (in GB)',
                                             //docID: 'helpContainerClusterNodeRootDiskSize',
                                             validation: {
-                                                required: true,
                                                 number: true
                                             }
                                         },
@@ -248,7 +247,8 @@
                                             label: 'Cluster size',
                                             //docID: 'helpContainerClusterSize',
                                             validation: {
-                                                required: true
+                                                required: true,
+                                                number: true
                                             },
                                         },
                                         sshkeypair: {
@@ -329,9 +329,14 @@
                                         zoneid: args.data.zone,
                                         serviceofferingid: args.data.serviceoffering,
                                         size: args.data.size,
-                                        keypair: args.data.sshkeypair,
-                                        noderootdisksize: args.data.noderootdisksize
+                                        keypair: args.data.sshkeypair
                                     };
+
+                                    if (args.data.noderootdisksize != null && args.data.noderootdisksize != "" && args.data.noderootdisksize > 0) {
+                                        $.extend(data, {
+                                            noderootdisksize: args.data.noderootdisksize
+                                        });
+                                    }
 
                                     if (args.data.supportPrivateRegistry) {
                                         $.extend(data, {


### PR DESCRIPTION
Added `scaleContainerCluster` API to scale container cluster to the desired size. It takes `id` of container cluster, new `serviceofferingid` and new `size` as parameter.
Only a container cluster in `Running` or `Created` state can be scaled for size currently.
A `Running`, `Stopped` or `Created` container cluster can be scaled for service offering but the current CoreOS template is not dynamically scalable.
UI has also been provided a new action item and dialog for scaling a container cluster.

Added support for dynamic root disk size for container cluster nodes. `createContainerCluster` API has been added with `noderootdisksize` parameter to provide a custom disk size for cluster nodes in GB. The corresponding field has also been in added in create form in the UI.

Changes also includes stability fixes for container cluster lifecycle.

## Screenshots
![Screenshot from 2019-07-26 16-12-30](https://user-images.githubusercontent.com/153340/61946902-620bcc00-afc1-11e9-9351-d4ef4377bba2.png)
![Screenshot from 2019-08-01 17-38-51](https://user-images.githubusercontent.com/153340/62292531-376bb880-b484-11e9-9c9e-cfaf44ae5d9a.png)
![Screenshot from 2019-08-01 17-40-04](https://user-images.githubusercontent.com/153340/62292535-3a66a900-b484-11e9-9f90-f299e5119fa2.png)

## API call
```
> scale containercluster size=2 id=83ee82ec-ecbd-4f63-ba3f-c0827eab8572
{
  "containercluster": {
    "associatednetworkname": "uiop-network",
    "consoleendpoint": "https://172.20.20.12:6443/api/v1/namespaces/kube-system/services/https:kubernetes-dashboard:/proxy#!/overview?namespace=_all",
    "cpunumber": "4",
    "description": "uiop",
    "endpoint": "https://172.20.20.12:6443/",
    "id": "83ee82ec-ecbd-4f63-ba3f-c0827eab8572",
    "keypair": "shwstppr",
    "memory": "4096",
    "name": "uiop",
    "networkid": "18313385-7380-4469-9c68-15ec9279c789",
    "serviceofferingid": "6d1e5106-6b97-4507-9b8b-52d73eeacb49",
    "serviceofferingname": "CCS Instance",
    "size": "2",
    "state": "Running",
    "templateid": "10407477-bdcb-4fe1-94d9-70c52c065664",
    "virtualmachineids": [
      "3d029b8e-2eb5-47e2-bc0c-6c37d46cc86a",
      "ab0765ab-b18e-459a-8448-3976f352f537",
      "3b2c5897-2e0f-4307-9727-65b586ac5e96"
    ],
    "zoneid": "faa5ba8b-6f81-4975-b58a-13c27dc195b1",
    "zonename": "KVM-advzone1"
  }
}

```

## How Has This Been Tested?
From UI and cmk.

- A new container cluster created using UI/cmk with cluster size=1
- Cluster is scaled using UI/cmk with cluster size=2
- UI state verified. API response is verified. Number instances, network rules verified from UI. Node count verified using kubectl tool.
- Cluster again scaled to size=1 using UI/cmk
- Again, UI state verified. API response is verified. Number instances, network rules verified from UI. Node count verified using kubectl tool.